### PR TITLE
Add code coverage CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - g++-8
+      - g++-7
       - libgflags-dev
+      - lcov
 
+# For GCC build, we also report code coverage to codecov.
 matrix:
   include:
-    - compiler: clang
-      env: BUILD_TYPE="Debug"
     - compiler: clang
       env: BUILD_TYPE="Release"
     - compiler: clang
@@ -25,23 +25,34 @@ matrix:
       env: SANITIZER="TSAN"
     - compiler: clang
       env: SANITIZER="UBSAN"
-    - env: COMPILER=gcc8
+    - env: COMPILER=gcc7
 
 install:
-  - git clone --depth=1 --branch=tikv-3.0 https://github.com/pingcap/rocksdb.git 
-  - if [ "${COMPILER}" == gcc8 ]; then
-      CC=gcc-8 && CXX=g++-8;
+  - git clone --depth=1 --branch=tikv-3.0 https://github.com/pingcap/rocksdb.git
+  - if [ "${COMPILER}" == gcc7 ]; then
+      CC=gcc-7;
+      CXX=g++-7;
+      COVERAGE_OPT="-DCODE_COVERAGE=ON";
     fi
   - if [ ! -z "${BUILD_TYPE}" ]; then
       BUILD_OPT="-DCMAKE_BUILD_TYPE=${BUILD_TYPE}";
+    else
+      BUILD_OPT="-DCMAKE_BUILD_TYPE=Debug";
     fi
   - if [ ! -z "${SANITIZER}" ]; then
-      SANITIZER_OPT="-DWITH_${SANITIZER}=ON" && TOOLS_OPT="-DWITH_TITAN_TOOLS=OFF";
+      SANITIZER_OPT="-DWITH_${SANITIZER}=ON";
+      TOOLS_OPT="-DWITH_TITAN_TOOLS=OFF";
     fi
 
 script:
-  - ${CXX} --version
-  - echo $BUILD_OPT
-  - echo $SANITIZER_OPT
-  - echo $TOOLS_OPT
-  - cmake . -DROCKSDB_DIR=./rocksdb -DTRAVIS=ON ${BUILD_OPT} ${SANITIZER_OPT} ${TOOLS_OPT} && make -j4 && ctest -R titan
+  - cmake . -L -DROCKSDB_DIR=./rocksdb -DTRAVIS=ON ${BUILD_OPT} ${SANITIZER_OPT} ${TOOLS_OPT} ${COVERAGE_OPT}
+  - make -j4
+  - ctest -R titan
+
+after_success:
+  - if [ "${COMPILER}" == gcc7 ]; then
+      lcov --gcov-tool gcov-7 --directory . --capture --output-file coverage.info;
+      lcov --remove coverage.info '/usr/*' --output-file coverage.info;
+      lcov --list coverage.info;
+      bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports";
+    fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,6 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
   set(WITH_TITAN_TESTS OFF)
 endif()
 
-# Enable gcov, which is available only for gcc.
 if (CODE_COVERAGE)
   target_compile_options(titan PRIVATE "--coverage")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,16 @@ add_library(titan STATIC ${SOURCES})
 option(WITH_TITAN_TESTS "Build with tests." ON)
 option(WITH_TITAN_TOOLS "Build with tools." ON)
 option(TRAVIS "Building in Travis." OFF)
+option(CODE_COVERAGE "Generate code coverage report." OFF)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
   set(WITH_TITAN_TESTS OFF)
+endif()
+
+# Enable gcov, which is available only for gcc.
+if (CODE_COVERAGE)
+  target_compile_options(titan PRIVATE "--coverage")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
 endif()
 
 if (WITH_TITAN_TESTS OR WITH_TITAN_TOOLS)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-[![Build Status](https://travis-ci.org/pingcap/titan.svg?branch=master)](https://travis-ci.org/pingcap/titan)
-
 # Titan: A RocksDB Plugin to Reduce Write Amplification
+
+[![Build Status](https://travis-ci.org/pingcap/titan.svg?branch=master)](https://travis-ci.org/pingcap/titan)
+[![codecov](https://codecov.io/gh/pingcap/titan/branch/master/graph/badge.svg)](https://codecov.io/gh/pingcap/titan)
 
 Titan is a RocksDB Plugin for key-value separation, inspired by 
 [WiscKey](https://www.usenix.org/system/files/conference/fast16/fast16-papers-lu.pdf).


### PR DESCRIPTION
use `lcov` to generate code coverage report together with GCC build, and send result to codecov. Also some minor refactor to travis config.

Signed-off-by: Yi Wu <yiwu@pingcap.com>