### PR TITLE
ignore missing blob file for iterator

### DIFF
--- a/include/titan/db.h
+++ b/include/titan/db.h
@@ -77,31 +77,6 @@ class TitanDB : public StackableDB {
   Status DestroyColumnFamilyHandle(ColumnFamilyHandle* column_family) override =
       0;
 
-  using StackableDB::Get;
-  Status Get(const ReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     PinnableSlice* value) override {
-        
-    return Get(TitanReadOptions(options), column_family, key, value);
-  }
-  virtual Status Get(const TitanReadOptions& options,
-                     ColumnFamilyHandle* column_family, const Slice& key,
-                     PinnableSlice* value) = 0;
-
-  using StackableDB::MultiGet;
-  std::vector<Status> MultiGet(
-      const ReadOptions& options,
-      const std::vector<ColumnFamilyHandle*>& column_family,
-      const std::vector<Slice>& keys,
-      std::vector<std::string>* values) override {
-    return MultiGet(TitanReadOptions(options), column_family, keys, values);
-  }
-  virtual std::vector<Status> MultiGet(
-      const TitanReadOptions& options,
-      const std::vector<ColumnFamilyHandle*>& column_family,
-      const std::vector<Slice>& keys,
-      std::vector<std::string>* values) = 0;
-
   using StackableDB::NewIterator;
   Iterator* NewIterator(const ReadOptions& opts,
                                 ColumnFamilyHandle* column_family) override {

--- a/include/titan/db.h
+++ b/include/titan/db.h
@@ -77,6 +77,51 @@ class TitanDB : public StackableDB {
   Status DestroyColumnFamilyHandle(ColumnFamilyHandle* column_family) override =
       0;
 
+  using StackableDB::Get;
+  Status Get(const ReadOptions& options,
+                     ColumnFamilyHandle* column_family, const Slice& key,
+                     PinnableSlice* value) override {
+        
+    return Get(TitanReadOptions(options), column_family, key, value);
+  }
+  virtual Status Get(const TitanReadOptions& options,
+                     ColumnFamilyHandle* column_family, const Slice& key,
+                     PinnableSlice* value) = 0;
+
+  using StackableDB::MultiGet;
+  std::vector<Status> MultiGet(
+      const ReadOptions& options,
+      const std::vector<ColumnFamilyHandle*>& column_family,
+      const std::vector<Slice>& keys,
+      std::vector<std::string>* values) override {
+    return MultiGet(TitanReadOptions(options), column_family, keys, values);
+  }
+  virtual std::vector<Status> MultiGet(
+      const TitanReadOptions& options,
+      const std::vector<ColumnFamilyHandle*>& column_family,
+      const std::vector<Slice>& keys,
+      std::vector<std::string>* values) = 0;
+
+  using StackableDB::NewIterator;
+  Iterator* NewIterator(const ReadOptions& opts,
+                                ColumnFamilyHandle* column_family) override {
+    return NewIterator(TitanReadOptions(opts), column_family);
+  }
+  virtual Iterator* NewIterator(const TitanReadOptions& opts,
+                                ColumnFamilyHandle* column_family) = 0;
+
+  using StackableDB::NewIterators;
+  Status NewIterators(
+      const ReadOptions& options,
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      std::vector<Iterator*>* iterators) override {
+    return NewIterators(TitanReadOptions(options), column_families, iterators);
+  }
+  virtual Status NewIterators(
+      const TitanReadOptions& options,
+      const std::vector<ColumnFamilyHandle*>& column_families,
+      std::vector<Iterator*>* iterators) = 0;
+
   using StackableDB::Merge;
   Status Merge(const WriteOptions&, ColumnFamilyHandle*, const Slice& /*key*/,
                const Slice& /*value*/) override {

--- a/include/titan/db.h
+++ b/include/titan/db.h
@@ -79,17 +79,16 @@ class TitanDB : public StackableDB {
 
   using StackableDB::NewIterator;
   Iterator* NewIterator(const ReadOptions& opts,
-                                ColumnFamilyHandle* column_family) override {
+                        ColumnFamilyHandle* column_family) override {
     return NewIterator(TitanReadOptions(opts), column_family);
   }
   virtual Iterator* NewIterator(const TitanReadOptions& opts,
                                 ColumnFamilyHandle* column_family) = 0;
 
   using StackableDB::NewIterators;
-  Status NewIterators(
-      const ReadOptions& options,
-      const std::vector<ColumnFamilyHandle*>& column_families,
-      std::vector<Iterator*>* iterators) override {
+  Status NewIterators(const ReadOptions& options,
+                      const std::vector<ColumnFamilyHandle*>& column_families,
+                      std::vector<Iterator*>* iterators) override {
     return NewIterators(TitanReadOptions(options), column_families, iterators);
   }
   virtual Status NewIterators(

--- a/include/titan/options.h
+++ b/include/titan/options.h
@@ -193,9 +193,10 @@ struct TitanOptions : public TitanDBOptions, public TitanCFOptions {
 
 struct TitanReadOptions : public ReadOptions {
   // If true, it will just return keys without indexing value from blob files.
-  // It is mainly used for the scan-delete operation after DeleteFilesInRange. Cause DeleteFilesInRange
-  // may expose old blob index keys, returning key only avoids referring to missing blob files.
-  // 
+  // It is mainly used for the scan-delete operation after DeleteFilesInRange.
+  // Cause DeleteFilesInRange may expose old blob index keys, returning key only
+  // avoids referring to missing blob files.
+  //
   // Default: false
   bool key_only{false};
 

--- a/include/titan/options.h
+++ b/include/titan/options.h
@@ -25,6 +25,11 @@ struct TitanDBOptions : public DBOptions {
   // Default: 1
   int32_t max_background_gc{1};
 
+  // How often to schedule delete obsolete blob files periods
+  //
+  // Default: 10
+  uint32_t purge_obsolete_files_period{10};  // 10s
+
   TitanDBOptions() = default;
   explicit TitanDBOptions(const DBOptions& options) : DBOptions(options) {}
 
@@ -183,6 +188,24 @@ struct TitanOptions : public TitanDBOptions, public TitanCFOptions {
     *dynamic_cast<ColumnFamilyOptions*>(&options) =
         *dynamic_cast<ColumnFamilyOptions*>(this);
     return options;
+  }
+};
+
+struct TitanReadOptions : public ReadOptions {
+  // If true, it will just return keys without indexing value from blob files.
+  // It is mainly used for the scan-delete operation after DeleteFilesInRange. Cause DeleteFilesInRange
+  // may expose old blob index keys, returning key only avoids referring to missing blob files.
+  // 
+  // Default: false
+  bool key_only{false};
+
+  TitanReadOptions() = default;
+  explicit TitanReadOptions(const ReadOptions& options)
+      : ReadOptions(options) {}
+
+  TitanReadOptions& operator=(const ReadOptions& options) {
+    *dynamic_cast<ReadOptions*>(this) = options;
+    return *this;
   }
 };
 

--- a/include/titan/options.h
+++ b/include/titan/options.h
@@ -177,16 +177,16 @@ struct TitanOptions : public TitanDBOptions, public TitanCFOptions {
       : TitanDBOptions(options), TitanCFOptions(options) {}
 
   TitanOptions& operator=(const Options& options) {
-    *dynamic_cast<TitanDBOptions*>(this) = options;
-    *dynamic_cast<TitanCFOptions*>(this) = options;
+    *static_cast<TitanDBOptions*>(this) = options;
+    *static_cast<TitanCFOptions*>(this) = options;
     return *this;
   }
 
   operator Options() {
     Options options;
-    *dynamic_cast<DBOptions*>(&options) = *dynamic_cast<DBOptions*>(this);
-    *dynamic_cast<ColumnFamilyOptions*>(&options) =
-        *dynamic_cast<ColumnFamilyOptions*>(this);
+    *static_cast<DBOptions*>(&options) = *static_cast<DBOptions*>(this);
+    *static_cast<ColumnFamilyOptions*>(&options) =
+        *static_cast<ColumnFamilyOptions*>(this);
     return options;
   }
 };
@@ -204,7 +204,7 @@ struct TitanReadOptions : public ReadOptions {
       : ReadOptions(options) {}
 
   TitanReadOptions& operator=(const ReadOptions& options) {
-    *dynamic_cast<ReadOptions*>(this) = options;
+    *static_cast<ReadOptions*>(this) = options;
     return *this;
   }
 };

--- a/src/blob_file_iterator_test.cc
+++ b/src/blob_file_iterator_test.cc
@@ -49,7 +49,7 @@ class BlobFileIteratorTest : public testing::Test {
     }
   }
 
-  void NewBuiler() {
+  void NewBuilder() {
     TitanDBOptions db_options(titan_options_);
     TitanCFOptions cf_options(titan_options_);
     BlobFileCache cache(db_options, cf_options, {NewLRUCache(128)}, nullptr);
@@ -73,7 +73,7 @@ class BlobFileIteratorTest : public testing::Test {
     ASSERT_OK(builder_->status());
   }
 
-  void FinishBuiler() {
+  void FinishBuilder() {
     ASSERT_OK(builder_->Finish());
     ASSERT_OK(builder_->status());
   }
@@ -88,7 +88,7 @@ class BlobFileIteratorTest : public testing::Test {
   }
 
   void TestBlobFileIterator() {
-    NewBuiler();
+    NewBuilder();
 
     const int n = 1000;
     std::vector<BlobHandle> handles(n);
@@ -97,7 +97,7 @@ class BlobFileIteratorTest : public testing::Test {
       AddKeyValue(id, id, &handles[i]);
     }
 
-    FinishBuiler();
+    FinishBuilder();
 
     NewBlobFileIterator();
 
@@ -120,7 +120,7 @@ TEST_F(BlobFileIteratorTest, Basic) {
 }
 
 TEST_F(BlobFileIteratorTest, IterateForPrev) {
-  NewBuiler();
+  NewBuilder();
   const int n = 1000;
   std::vector<BlobHandle> handles(n);
   for (int i = 0; i < n; i++) {
@@ -128,7 +128,7 @@ TEST_F(BlobFileIteratorTest, IterateForPrev) {
     AddKeyValue(id, id, &handles[i]);
   }
 
-  FinishBuiler();
+  FinishBuilder();
 
   NewBlobFileIterator();
 
@@ -181,11 +181,11 @@ TEST_F(BlobFileIteratorTest, MergeIterator) {
   const int kMaxKeyNum = 1000;
   std::vector<BlobHandle> handles(kMaxKeyNum);
   std::vector<std::unique_ptr<BlobFileIterator>> iters;
-  NewBuiler();
+  NewBuilder();
   for (int i = 1; i < kMaxKeyNum; i++) {
     AddKeyValue(GenKey(i), GenValue(i), &handles[i]);
     if (i % 100 == 0) {
-      FinishBuiler();
+      FinishBuilder();
       uint64_t file_size = 0;
       ASSERT_OK(env_->GetFileSize(file_name_, &file_size));
       NewBlobFileReader(file_number_, 0, titan_options_, env_options_, env_,
@@ -195,11 +195,11 @@ TEST_F(BlobFileIteratorTest, MergeIterator) {
                                file_size, TitanCFOptions()}));
       file_number_ = Random::GetTLSInstance()->Next();
       file_name_ = BlobFileName(dirname_, file_number_);
-      NewBuiler();
+      NewBuilder();
     }
   }
 
-  FinishBuiler();
+  FinishBuilder();
   uint64_t file_size = 0;
   ASSERT_OK(env_->GetFileSize(file_name_, &file_size));
   NewBlobFileReader(file_number_, 0, titan_options_, env_options_, env_,

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -214,7 +214,7 @@ bool BlobGCJob::DoSample(const BlobFileMeta* file) {
 
   return discardable_size >=
          std::ceil(sample_size_window *
-             blob_gc_->titan_cf_options().blob_file_discardable_ratio);
+                   blob_gc_->titan_cf_options().blob_file_discardable_ratio);
 }
 
 Status BlobGCJob::DoRunGC() {

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -161,13 +161,15 @@ bool BlobGCJob::DoSample(const BlobFileMeta* file) {
   }
 
   // TODO: add do sample count metrics
-  auto records_size = file->file_size() - BlobFileHeader::kEncodedLength - BlobFileFooter::kEncodedLength;
+  auto records_size = file->file_size() - BlobFileHeader::kEncodedLength -
+                      BlobFileFooter::kEncodedLength;
   Status s;
   uint64_t sample_size_window = static_cast<uint64_t>(
       records_size * blob_gc_->titan_cf_options().sample_file_size_ratio);
   Random64 random64(records_size);
   uint64_t sample_begin_offset =
-      random64.Uniform(records_size - sample_size_window) + BlobFileHeader::kEncodedLength;
+      random64.Uniform(records_size - sample_size_window) +
+      BlobFileHeader::kEncodedLength;
 
   std::unique_ptr<RandomAccessFileReader> file_reader;
   const int readahead = 256 << 10;

--- a/src/blob_gc_job_test.cc
+++ b/src/blob_gc_job_test.cc
@@ -341,8 +341,6 @@ TEST_F(BlobGCJobTest, DeleteFilesInRange) {
   ASSERT_EQ(value, "1");
 
   RunGC(true);
-  ASSERT_OK(db_->Put(WriteOptions(), GenKey(5), GenValue(5)));
-  RunGC();
 
   std::string key0 = GenKey(0);
   std::string key3 = GenKey(3);

--- a/src/blob_gc_job_test.cc
+++ b/src/blob_gc_job_test.cc
@@ -1,6 +1,7 @@
 #include "blob_gc_job.h"
 
 #include "blob_gc_picker.h"
+#include "rocksdb/convenience.h"
 #include "db_impl.h"
 #include "util/testharness.h"
 
@@ -36,6 +37,7 @@ class BlobGCJobTest : public testing::Test {
     options_.create_if_missing = true;
     options_.disable_background_gc = true;
     options_.min_blob_size = 0;
+    options_.disable_auto_compactions = true;
     options_.env->CreateDirIfMissing(dbname_);
     options_.env->CreateDirIfMissing(options_.dirname);
   }
@@ -84,6 +86,15 @@ class BlobGCJobTest : public testing::Test {
     ASSERT_OK(db_->Flush(fopts));
   }
 
+  void CompactAll() {
+    auto opts = db_->GetOptions();
+    auto compact_opts = CompactRangeOptions();
+    compact_opts.change_level = true;
+    compact_opts.target_level = opts.num_levels - 1;
+    compact_opts.bottommost_level_compaction = BottommostLevelCompaction::kSkip;
+    ASSERT_OK(db_->CompactRange(compact_opts, nullptr, nullptr));
+  }
+
   void DestroyDB() {
     Status s __attribute__((__unused__)) = db_->Close();
     assert(s.ok());
@@ -91,7 +102,7 @@ class BlobGCJobTest : public testing::Test {
     db_ = nullptr;
   }
 
-  void RunGC() {
+  void RunGC(bool expected = false) {
     MutexLock l(mutex_);
     Status s;
     auto* cfh = base_db_->DefaultColumnFamily();
@@ -102,6 +113,7 @@ class BlobGCJobTest : public testing::Test {
     LogBuffer log_buffer(InfoLogLevel::INFO_LEVEL, db_options.info_log.get());
     cf_options.min_gc_batch_size = 0;
     cf_options.blob_file_discardable_ratio = 0.4;
+    cf_options.sample_file_size_ratio = 1;
 
     std::unique_ptr<BlobGC> blob_gc;
     {
@@ -109,6 +121,10 @@ class BlobGCJobTest : public testing::Test {
           std::make_shared<BasicBlobGCPicker>(db_options, cf_options);
       blob_gc = blob_gc_picker->PickBlobGC(
           version_set_->GetBlobStorage(cfh->GetID()).lock().get());
+    }
+
+    if (expected) {
+      ASSERT_TRUE(blob_gc != nullptr);
     }
 
     if (blob_gc) {
@@ -124,9 +140,12 @@ class BlobGCJobTest : public testing::Test {
       {
         mutex_->Unlock();
         s = blob_gc_job.Run();
+        if (expected) {
+          ASSERT_OK(s);
+        }
         mutex_->Lock();
       }
-
+      
       if (s.ok()) {
         s = blob_gc_job.Finish();
         ASSERT_OK(s);
@@ -290,6 +309,63 @@ TEST_F(BlobGCJobTest, PurgeBlobs) {
   db_->ReleaseSnapshot(snap5);
   RunGC();
   CheckBlobNumber(1);
+
+  DestroyDB();
+}
+
+TEST_F(BlobGCJobTest, DeleteFilesInRange) {
+  NewDB();
+
+  ASSERT_OK(db_->Put(WriteOptions(), GenKey(2), GenValue(21)));
+  ASSERT_OK(db_->Put(WriteOptions(), GenKey(4), GenValue(4)));
+  Flush();
+  CompactAll();
+  std::string value;
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-files-at-level0", &value));
+  ASSERT_EQ(value, "0");
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-files-at-level6", &value));
+  ASSERT_EQ(value, "1");
+  
+  SstFileWriter sst_file_writer(EnvOptions(), options_);
+  std::string sst_file = options_.dirname + "/for_ingest.sst";
+  ASSERT_OK(sst_file_writer.Open(sst_file));
+  ASSERT_OK(sst_file_writer.Put(GenKey(1), GenValue(1)));
+  ASSERT_OK(sst_file_writer.Put(GenKey(2), GenValue(22)));
+  ASSERT_OK(sst_file_writer.Finish());
+  ASSERT_OK(db_->IngestExternalFile({sst_file}, IngestExternalFileOptions()));
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-files-at-level0", &value));
+  ASSERT_EQ(value, "0");
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-files-at-level5", &value));
+  ASSERT_EQ(value, "1");
+  ASSERT_TRUE(db_->GetProperty("rocksdb.num-files-at-level6", &value));
+  ASSERT_EQ(value, "1");
+
+  RunGC(true);
+  ASSERT_OK(db_->Put(WriteOptions(), GenKey(5), GenValue(5)));
+  RunGC();
+
+  std::string key0 = GenKey(0);
+  std::string key3 = GenKey(3);
+  Slice start = Slice(key0);
+  Slice end = Slice(key3);
+  ASSERT_OK(DeleteFilesInRange(base_db_, db_->DefaultColumnFamily(), &start, &end));
+  TitanReadOptions opts;
+  auto* iter = db_->NewIterator(opts, db_->DefaultColumnFamily());
+  iter->SeekToFirst();
+  while (iter->Valid()) {
+    iter->Next();
+  }
+  ASSERT_TRUE(iter->status().IsCorruption());
+  delete iter;
+
+  opts.key_only = true;
+  iter = db_->NewIterator(opts, db_->DefaultColumnFamily());
+  iter->SeekToFirst();
+  while (iter->Valid()) {
+    iter->Next();
+  }
+  ASSERT_OK(iter->status());
+  delete iter;
 
   DestroyDB();
 }

--- a/src/blob_gc_job_test.cc
+++ b/src/blob_gc_job_test.cc
@@ -1,8 +1,8 @@
 #include "blob_gc_job.h"
 
 #include "blob_gc_picker.h"
-#include "rocksdb/convenience.h"
 #include "db_impl.h"
+#include "rocksdb/convenience.h"
 #include "util/testharness.h"
 
 namespace rocksdb {
@@ -145,7 +145,7 @@ class BlobGCJobTest : public testing::Test {
         }
         mutex_->Lock();
       }
-      
+
       if (s.ok()) {
         s = blob_gc_job.Finish();
         ASSERT_OK(s);
@@ -325,7 +325,7 @@ TEST_F(BlobGCJobTest, DeleteFilesInRange) {
   ASSERT_EQ(value, "0");
   ASSERT_TRUE(db_->GetProperty("rocksdb.num-files-at-level6", &value));
   ASSERT_EQ(value, "1");
-  
+
   SstFileWriter sst_file_writer(EnvOptions(), options_);
   std::string sst_file = options_.dirname + "/for_ingest.sst";
   ASSERT_OK(sst_file_writer.Open(sst_file));
@@ -346,7 +346,8 @@ TEST_F(BlobGCJobTest, DeleteFilesInRange) {
   std::string key3 = GenKey(3);
   Slice start = Slice(key0);
   Slice end = Slice(key3);
-  ASSERT_OK(DeleteFilesInRange(base_db_, db_->DefaultColumnFamily(), &start, &end));
+  ASSERT_OK(
+      DeleteFilesInRange(base_db_, db_->DefaultColumnFamily(), &start, &end));
   TitanReadOptions opts;
   auto* iter = db_->NewIterator(opts, db_->DefaultColumnFamily());
   iter->SeekToFirst();

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -358,19 +358,18 @@ Status TitanDBImpl::CompactFiles(
   return s;
 }
 
-Status TitanDBImpl::Get(const TitanReadOptions& options,
-                        ColumnFamilyHandle* handle, const Slice& key,
-                        PinnableSlice* value) {
+Status TitanDBImpl::Get(const ReadOptions& options, ColumnFamilyHandle* handle,
+                        const Slice& key, PinnableSlice* value) {
   if (options.snapshot) {
     return GetImpl(options, handle, key, value);
   }
-  TitanReadOptions ro(options);
+  ReadOptions ro(options);
   ManagedSnapshot snapshot(this);
   ro.snapshot = snapshot.snapshot();
   return GetImpl(ro, handle, key, value);
 }
 
-Status TitanDBImpl::GetImpl(const TitanReadOptions& options,
+Status TitanDBImpl::GetImpl(const ReadOptions& options,
                             ColumnFamilyHandle* handle, const Slice& key,
                             PinnableSlice* value) {
   Status s;
@@ -416,23 +415,21 @@ Status TitanDBImpl::GetImpl(const TitanReadOptions& options,
 }
 
 std::vector<Status> TitanDBImpl::MultiGet(
-    const TitanReadOptions& options,
-    const std::vector<ColumnFamilyHandle*>& handles,
+    const ReadOptions& options, const std::vector<ColumnFamilyHandle*>& handles,
     const std::vector<Slice>& keys, std::vector<std::string>* values) {
   auto options_copy = options;
   options_copy.total_order_seek = true;
   if (options_copy.snapshot) {
     return MultiGetImpl(options_copy, handles, keys, values);
   }
-  TitanReadOptions ro(options_copy);
+  ReadOptions ro(options_copy);
   ManagedSnapshot snapshot(this);
   ro.snapshot = snapshot.snapshot();
   return MultiGetImpl(ro, handles, keys, values);
 }
 
 std::vector<Status> TitanDBImpl::MultiGetImpl(
-    const TitanReadOptions& options,
-    const std::vector<ColumnFamilyHandle*>& handles,
+    const ReadOptions& options, const std::vector<ColumnFamilyHandle*>& handles,
     const std::vector<Slice>& keys, std::vector<std::string>* values) {
   std::vector<Status> res;
   res.resize(keys.size());

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -44,11 +44,11 @@ class TitanDBImpl : public TitanDB {
   Status CloseImpl();
 
   using TitanDB::Get;
-  Status Get(const TitanReadOptions& options, ColumnFamilyHandle* handle,
+  Status Get(const ReadOptions& options, ColumnFamilyHandle* handle,
              const Slice& key, PinnableSlice* value) override;
 
   using TitanDB::MultiGet;
-  std::vector<Status> MultiGet(const TitanReadOptions& options,
+  std::vector<Status> MultiGet(const ReadOptions& options,
                                const std::vector<ColumnFamilyHandle*>& handles,
                                const std::vector<Slice>& keys,
                                std::vector<std::string>* values) override;
@@ -96,11 +96,11 @@ class TitanDBImpl : public TitanDB {
   friend class TitanDBTest;
   friend class TitanThreadSafetyTest;
 
-  Status GetImpl(const TitanReadOptions& options, ColumnFamilyHandle* handle,
+  Status GetImpl(const ReadOptions& options, ColumnFamilyHandle* handle,
                  const Slice& key, PinnableSlice* value);
 
   std::vector<Status> MultiGetImpl(
-      const TitanReadOptions& options,
+      const ReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& handles,
       const std::vector<Slice>& keys, std::vector<std::string>* values);
 

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -44,20 +44,21 @@ class TitanDBImpl : public TitanDB {
   Status CloseImpl();
 
   using TitanDB::Get;
-  Status Get(const ReadOptions& options, ColumnFamilyHandle* handle,
+  Status Get(const TitanReadOptions& options, ColumnFamilyHandle* handle,
              const Slice& key, PinnableSlice* value) override;
 
   using TitanDB::MultiGet;
-  std::vector<Status> MultiGet(const ReadOptions& options,
+  std::vector<Status> MultiGet(const TitanReadOptions& options,
                                const std::vector<ColumnFamilyHandle*>& handles,
                                const std::vector<Slice>& keys,
                                std::vector<std::string>* values) override;
 
   using TitanDB::NewIterator;
-  Iterator* NewIterator(const ReadOptions& options,
+  Iterator* NewIterator(const TitanReadOptions& options,
                         ColumnFamilyHandle* handle) override;
 
-  Status NewIterators(const ReadOptions& options,
+  using TitanDB::NewIterators;
+  Status NewIterators(const TitanReadOptions& options,
                       const std::vector<ColumnFamilyHandle*>& handles,
                       std::vector<Iterator*>* iterators) override;
 
@@ -95,15 +96,15 @@ class TitanDBImpl : public TitanDB {
   friend class TitanDBTest;
   friend class TitanThreadSafetyTest;
 
-  Status GetImpl(const ReadOptions& options, ColumnFamilyHandle* handle,
+  Status GetImpl(const TitanReadOptions& options, ColumnFamilyHandle* handle,
                  const Slice& key, PinnableSlice* value);
 
   std::vector<Status> MultiGetImpl(
-      const ReadOptions& options,
+      const TitanReadOptions& options,
       const std::vector<ColumnFamilyHandle*>& handles,
       const std::vector<Slice>& keys, std::vector<std::string>* values);
 
-  Iterator* NewIteratorImpl(const ReadOptions& options,
+  Iterator* NewIteratorImpl(const TitanReadOptions& options,
                             ColumnFamilyHandle* handle,
                             std::shared_ptr<ManagedSnapshot> snapshot);
 

--- a/src/db_iter.h
+++ b/src/db_iter.h
@@ -99,6 +99,7 @@ class TitanDBIterator : public Iterator {
 
   Slice value() const override {
     assert(Valid() && !options_.key_only);
+    if (options_.key_only) return Slice();
     if (!iter_->IsBlob()) return iter_->value();
     return record_.value;
   }


### PR DESCRIPTION
- add key-only iter option
- reproduce missing blob file when iterating
- fix an issue about sample which affecting reproducing