### PR TITLE
Disable compactions on initial open of rocksdb

### DIFF
--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -156,8 +156,12 @@ Status TitanDBImpl::Open(const std::vector<TitanCFDescriptor>& descs,
   s = env_->LockFile(LockFileName(dirname_), &lock_);
   if (!s.ok()) return s;
 
+  // Descriptors for initial DB open to get CF ids.
+  std::vector<ColumnFamilyDescriptor> init_descs;
+  // Descriptors for actually open DB.
   std::vector<ColumnFamilyDescriptor> base_descs;
   for (auto& desc : descs) {
+    init_descs.emplace_back(desc.name, desc.options);
     base_descs.emplace_back(desc.name, desc.options);
   }
   std::map<uint32_t, TitanCFOptions> column_families;
@@ -173,10 +177,11 @@ Status TitanDBImpl::Open(const std::vector<TitanCFDescriptor>& descs,
   // We also avoid flush here because we haven't replaced the table factory
   // yet, but rocksdb may still flush if memtable is full. This is fine though,
   // since values in memtable are raw values.
-  bool tmp_disable_auto_compactions = db_options_.disable_auto_compactions;
-  db_options_.disable_auto_compactions = true;
+  for (auto& desc : init_descs) {
+    desc.options.disable_auto_compactions = true;
+  }
   db_options_.avoid_flush_during_recovery = true;
-  s = DB::Open(db_options_, dbname_, base_descs, handles, &db_);
+  s = DB::Open(db_options_, dbname_, init_descs, handles, &db_);
   if (s.ok()) {
     for (size_t i = 0; i < descs.size(); i++) {
       auto handle = (*handles)[i];
@@ -201,7 +206,6 @@ Status TitanDBImpl::Open(const std::vector<TitanCFDescriptor>& descs,
     delete db_;
   }
   if (!s.ok()) return s;
-  db_options_.disable_auto_compactions = tmp_disable_auto_compactions;
 
   s = vset_->Open(column_families);
   if (!s.ok()) return s;


### PR DESCRIPTION
Summary:
On `TitanDBImpl::Open` we open rocksdb twice, and the first time is just to get list of CFs and construct table factory. Compaction can run at this point, generating SST files without custom table property. This can cause problem later on, since `OnCompactionCompleted` assume the property always exist and even use it to detect new blob file generated from the compaction. This patch disable auto compaction for the first rocksdb open to avoid such problem.

The test shown here demo the issue without disabling compaction: https://gist.github.com/yiwu-arbug/34c561d0daf4f9c293bb7b2825d77bf2

Test Plan:
Existing tests

Signed-off-by: Yi Wu <yiwu@pingcap.com>