### PR TITLE
Fix fallback mode fail when it encounter GC-ed file

### DIFF
--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -88,6 +88,9 @@ class TitanDBImpl : public TitanDB {
 
   void StartBackgroundTasks();
 
+  Status TEST_StartGC(uint32_t column_family_id);
+  Status TEST_PurgeObsoleteFiles();
+
  private:
   class FileManager;
   friend class FileManager;
@@ -128,9 +131,9 @@ class TitanDBImpl : public TitanDB {
   static void BGWorkGC(void* db);
   void BackgroundCallGC();
   Status BackgroundGC(LogBuffer* log_buffer);
-  Status TEST_StartGC(uint32_t column_family_id);
 
   void PurgeObsoleteFiles();
+  Status PurgeObsoleteFilesImpl();
 
   SequenceNumber GetOldestSnapshotSequence() {
     SequenceNumber oldest_snapshot = kMaxSequenceNumber;

--- a/src/db_impl_files.cc
+++ b/src/db_impl_files.cc
@@ -3,7 +3,7 @@
 namespace rocksdb {
 namespace titandb {
 
-void TitanDBImpl::PurgeObsoleteFiles() {
+Status TitanDBImpl::PurgeObsoleteFilesImpl() {
   Status s;
   std::vector<std::string> candidate_files;
   auto oldest_sequence = GetOldestSnapshotSequence();
@@ -22,13 +22,21 @@ void TitanDBImpl::PurgeObsoleteFiles() {
   for (const auto& candidate_file : candidate_files) {
     ROCKS_LOG_INFO(db_options_.info_log, "Titan deleting obsolete file [%s]",
                    candidate_file.c_str());
-    s = env_->DeleteFile(candidate_file);
+    Status delete_status = env_->DeleteFile(candidate_file);
     if (!s.ok()) {
-      fprintf(stderr, "Titan deleting file [%s] failed, status:%s",
-              candidate_file.c_str(), s.ToString().c_str());
-      abort();
+      s = delete_status;
     }
   }
+  return s;
+}
+
+void TitanDBImpl::PurgeObsoleteFiles() {
+  Status s __attribute__((__unused__)) = PurgeObsoleteFilesImpl();
+  assert(s.ok());
+}
+
+Status TitanDBImpl::TEST_PurgeObsoleteFiles() {
+  return PurgeObsoleteFilesImpl();
 }
 
 }  // namespace titandb


### PR DESCRIPTION
Summary:
In fallback mode, table builder will try to read value from blob file and write the value back to LSM. If the corresponding blob file had been GC-ed and deleted, however, table builder will return error and fail compaction. Fixing it by writing the blob index to output if table builder get error when reading blob value.

Test Plan:
See the new test.

Signed-off-by: Yi Wu <yiwu@pingcap.com>