### PR TITLE
Add GetTitanOptions() and other options related changes

### DIFF
--- a/include/titan/db.h
+++ b/include/titan/db.h
@@ -127,10 +127,18 @@ class TitanDB : public StackableDB {
   using rocksdb::StackableDB::GetOptions;
   Options GetOptions(ColumnFamilyHandle* column_family) const override = 0;
 
+  virtual TitanOptions GetTitanOptions(
+      ColumnFamilyHandle* column_family) const = 0;
+  virtual TitanOptions GetTitanOptions() const {
+    return GetTitanOptions(DefaultColumnFamily());
+  }
+
   using rocksdb::StackableDB::SetOptions;
   Status SetOptions(ColumnFamilyHandle* column_family,
                     const std::unordered_map<std::string, std::string>&
                         new_options) override = 0;
+
+  virtual TitanDBOptions GetTitanDBOptions() const = 0;
 
   struct Properties {
     //  "rocksdb.titandb.live-blob-size" - returns total blob value size

--- a/include/titan/options.h
+++ b/include/titan/options.h
@@ -121,15 +121,14 @@ struct TitanCFOptions : public ColumnFamilyOptions {
   TitanCFOptions() = default;
   explicit TitanCFOptions(const ColumnFamilyOptions& options)
       : ColumnFamilyOptions(options) {}
-  explicit TitanCFOptions(const ImmutableTitanCFOptions&,
+  explicit TitanCFOptions(const ColumnFamilyOptions&,
+                          const ImmutableTitanCFOptions&,
                           const MutableTitanCFOptions&);
 
   TitanCFOptions& operator=(const ColumnFamilyOptions& options) {
     *dynamic_cast<ColumnFamilyOptions*>(this) = options;
     return *this;
   }
-
-  std::string ToString() const;
 
   void Dump(Logger* logger) const;
 };

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -661,7 +661,7 @@ TitanDBOptions TitanDBImpl::GetTitanDBOptions() const {
   // Titan db_options_ is not mutable after DB open.
   TitanDBOptions result = db_options_;
   *static_cast<DBOptions*>(&result) = db_impl_->GetDBOptions();
-  return db_options_;
+  return result;
 }
 
 bool TitanDBImpl::GetProperty(ColumnFamilyHandle* column_family,

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -74,6 +74,13 @@ class TitanDBImpl : public TitanDB {
       ColumnFamilyHandle* column_family,
       const std::unordered_map<std::string, std::string>& new_options) override;
 
+  using TitanDB::GetTitanOptions;
+  TitanOptions GetTitanOptions(
+      ColumnFamilyHandle* column_family) const override;
+
+  using TitanDB::GetTitanDBOptions;
+  TitanDBOptions GetTitanDBOptions() const override;
+
   using TitanDB::GetProperty;
   bool GetProperty(ColumnFamilyHandle* column_family, const Slice& property,
                    std::string* value) override;
@@ -169,8 +176,17 @@ class TitanDBImpl : public TitanDB {
   // is not null.
   std::unique_ptr<TitanStats> stats_;
 
+  // Guarded by mutex_.
+  std::unordered_map<uint32_t, ImmutableTitanCFOptions> immutable_cf_options_;
+
+  // Guarded by mutex_.
+  std::unordered_map<uint32_t, MutableTitanCFOptions> mutable_cf_options_;
+
+  // Guarded by mutex_.
   std::unordered_map<uint32_t, std::shared_ptr<TableFactory>>
       base_table_factory_;
+
+  // Guarded by mutex_.
   std::unordered_map<uint32_t, std::shared_ptr<TitanTableFactory>>
       titan_table_factory_;
 

--- a/src/options.cc
+++ b/src/options.cc
@@ -14,17 +14,23 @@ namespace rocksdb {
 namespace titandb {
 
 void TitanDBOptions::Dump(Logger* logger) const {
-  ROCKS_LOG_HEADER(logger, "TitanDBOptions.dirname                : %s",
+  ROCKS_LOG_HEADER(logger, "TitanDBOptions.dirname                    : %s",
                    dirname.c_str());
-  ROCKS_LOG_HEADER(logger, "TitanDBOptions.disable_background_gc  : %d",
+  ROCKS_LOG_HEADER(logger, "TitanDBOptions.disable_background_gc      : %d",
                    static_cast<int>(disable_background_gc));
-  ROCKS_LOG_HEADER(logger, "TitanDBOptions.max_background_gc      : %" PRIi32,
-                   static_cast<int>(disable_background_gc));
+  ROCKS_LOG_HEADER(logger,
+                   "TitanDBOptions.max_background_gc          : %" PRIi32,
+                   max_background_gc);
+  ROCKS_LOG_HEADER(logger,
+                   "TitanDBOptions.purge_obsolete_files_period: %" PRIu32,
+                   purge_obsolete_files_period);
 }
 
-TitanCFOptions::TitanCFOptions(const ImmutableTitanCFOptions& immutable_opts,
+TitanCFOptions::TitanCFOptions(const ColumnFamilyOptions& cf_opts,
+                               const ImmutableTitanCFOptions& immutable_opts,
                                const MutableTitanCFOptions& mutable_opts)
-    : min_blob_size(immutable_opts.min_blob_size),
+    : ColumnFamilyOptions(cf_opts),
+      min_blob_size(immutable_opts.min_blob_size),
       blob_file_compression(immutable_opts.blob_file_compression),
       blob_file_target_size(immutable_opts.blob_file_target_size),
       blob_cache(immutable_opts.blob_cache),
@@ -34,24 +40,6 @@ TitanCFOptions::TitanCFOptions(const ImmutableTitanCFOptions& immutable_opts,
       sample_file_size_ratio(immutable_opts.sample_file_size_ratio),
       merge_small_file_threshold(immutable_opts.merge_small_file_threshold),
       blob_run_mode(mutable_opts.blob_run_mode) {}
-
-std::string TitanCFOptions::ToString() const {
-  char buf[256];
-  std::string str;
-  std::string res = "[titandb]\n";
-  snprintf(buf, sizeof(buf), "min_blob_size = %" PRIu64 "\n", min_blob_size);
-  res += buf;
-  GetStringFromCompressionType(&str, blob_file_compression);
-  snprintf(buf, sizeof(buf), "blob_file_compression = %s\n", str.c_str());
-  res += buf;
-  snprintf(buf, sizeof(buf), "blob_file_target_size = %" PRIu64 "\n",
-           blob_file_target_size);
-  res += buf;
-  snprintf(buf, sizeof(buf), "blob_run_mode = %s\n",
-           blob_run_mode_to_string[blob_run_mode].c_str());
-  res += buf;
-  return res;
-}
 
 void TitanCFOptions::Dump(Logger* logger) const {
   ROCKS_LOG_HEADER(logger,

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -645,6 +645,8 @@ TEST_F(TitanDBTest, SetOptions) {
   ASSERT_OK(db_->SetDBOptions(opts));
   titan_options = db_->GetTitanOptions();
   ASSERT_EQ(15, titan_options.max_background_jobs);
+  TitanDBOptions titan_db_options = db_->GetTitanDBOptions();
+  ASSERT_EQ(15, titan_db_options.max_background_jobs);
 }
 
 TEST_F(TitanDBTest, BlobRunModeBasic) {

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -613,15 +613,38 @@ TEST_F(TitanDBTest, BlobFileCorruptionErrorHandling) {
 }
 #endif  // !NDEBUG
 
-TEST_F(TitanDBTest, Options) {
+TEST_F(TitanDBTest, SetOptions) {
+  options_.write_buffer_size = 42000000;
+  options_.min_blob_size = 123;
+  options_.blob_run_mode = TitanBlobRunMode::kReadOnly;
   Open();
 
+  TitanOptions titan_options = db_->GetTitanOptions();
+  ASSERT_EQ(42000000, titan_options.write_buffer_size);
+  ASSERT_EQ(123, titan_options.min_blob_size);
+  ASSERT_EQ(TitanBlobRunMode::kReadOnly, titan_options.blob_run_mode);
+
   std::unordered_map<std::string, std::string> opts;
+
+  // Set titan options.
   opts["blob_run_mode"] = "kReadOnly";
   ASSERT_OK(db_->SetOptions(opts));
+  titan_options = db_->GetTitanOptions();
+  ASSERT_EQ(TitanBlobRunMode::kReadOnly, titan_options.blob_run_mode);
+  opts.clear();
 
+  // Set column family options.
   opts["disable_auto_compactions"] = "true";
   ASSERT_OK(db_->SetOptions(opts));
+  titan_options = db_->GetTitanOptions();
+  ASSERT_TRUE(titan_options.disable_auto_compactions);
+  opts.clear();
+
+  // Set DB options.
+  opts["max_background_jobs"] = "15";
+  ASSERT_OK(db_->SetDBOptions(opts));
+  titan_options = db_->GetTitanOptions();
+  ASSERT_EQ(15, titan_options.max_background_jobs);
 }
 
 TEST_F(TitanDBTest, BlobRunModeBasic) {


### PR DESCRIPTION
Summary:
* Add `GetTitanOptions()` and `GetTitanDBOptions()` API.
* Fix `SetOptions()` fail when `blob_run_mode` is not set.
* Update info log around printing options.

Test Plan:
Updated test.

Signed-off-by: Yi Wu <yiwu@pingcap.com>