### PR TITLE
Check edits before written to manifest

### DIFF
--- a/src/edit_collector.h
+++ b/src/edit_collector.h
@@ -20,7 +20,7 @@ class EditCollector {
   Status AddEdit(const VersionEdit& edit) {
     if (sealed_)
       return Status::Corruption(
-          "Should be not called after Sealed() is called.");
+          "Should be not called after Sealed() is called");
 
     auto cf_id = edit.column_family_id_;
     auto& collector = column_families_[cf_id];
@@ -75,7 +75,7 @@ class EditCollector {
     if (!status_.ok()) return status_;
     if (!sealed_)
       return Status::Corruption(
-          "Should be not called until Sealed() is called.");
+          "Should be not called until Sealed() is called");
 
     for (auto& cf : column_families_) {
       auto cf_id = cf.first;
@@ -188,7 +188,8 @@ class EditCollector {
         }
         auto blob = storage->FindFile(number).lock();
         if (!blob) {
-          return Status::NotFound("invalid file number");
+          return Status::NotFound("Invalid file number " +
+                                  std::to_string(number));
         }
         storage->MarkFileObsolete(blob, file.second);
       }

--- a/src/edit_collector.h
+++ b/src/edit_collector.h
@@ -19,7 +19,7 @@ class EditCollector {
   // Add the edit into the batch.
   Status AddEdit(const VersionEdit& edit) {
     if (sealed_)
-      return Status::Corruption(
+      return Status::Incomplete(
           "Should be not called after Sealed() is called");
 
     auto cf_id = edit.column_family_id_;
@@ -74,7 +74,7 @@ class EditCollector {
   Status Apply(VersionSet& vset) {
     if (!status_.ok()) return status_;
     if (!sealed_)
-      return Status::Corruption(
+      return Status::Incomplete(
           "Should be not called until Sealed() is called");
 
     for (auto& cf : column_families_) {

--- a/src/version_set.cc
+++ b/src/version_set.cc
@@ -82,7 +82,7 @@ Status VersionSet::Recover() {
       s = collector.AddEdit(edit);
       if (!s.ok()) return s;
     }
-    s = collector.Check(*this);
+    s = collector.Seal(*this);
     if (!s.ok()) return s;
     s = collector.Apply(*this);
     if (!s.ok()) return s;
@@ -216,7 +216,7 @@ Status VersionSet::LogAndApply(VersionEdit& edit) {
   EditCollector collector;
   Status s = collector.AddEdit(edit);
   if (!s.ok()) return s;
-  s = collector.Check(*this);
+  s = collector.Seal(*this);
   if (!s.ok()) return s;
   s = manifest_->AddRecord(record);
   if (!s.ok()) return s;

--- a/src/version_test.cc
+++ b/src/version_test.cc
@@ -83,7 +83,7 @@ class VersionTest : public testing::Test {
     for (auto& edit : edits) {
       ASSERT_OK(collector.AddEdit(edit));
     }
-    ASSERT_OK(collector.Check(*vset_.get()));
+    ASSERT_OK(collector.Seal(*vset_.get()));
     ASSERT_OK(collector.Apply(*vset_.get()));
     for (auto& it : vset_->column_families_) {
       auto& storage = column_families_[it.first];
@@ -148,7 +148,7 @@ TEST_F(VersionTest, InvalidEdit) {
     auto add1_0_4 = AddBlobFilesEdit(1, 0, 4);
     EditCollector collector;
     ASSERT_OK(collector.AddEdit(add1_0_4));
-    ASSERT_OK(collector.Check(*vset_.get()));
+    ASSERT_OK(collector.Seal(*vset_.get()));
     ASSERT_OK(collector.Apply(*vset_.get()));
   }
 
@@ -157,7 +157,7 @@ TEST_F(VersionTest, InvalidEdit) {
     auto del1_4_6 = DeleteBlobFilesEdit(1, 4, 6);
     EditCollector collector;
     ASSERT_OK(collector.AddEdit(del1_4_6));
-    ASSERT_NOK(collector.Check(*vset_.get()));
+    ASSERT_NOK(collector.Seal(*vset_.get()));
     ASSERT_NOK(collector.Apply(*vset_.get()));
   }
 
@@ -166,7 +166,7 @@ TEST_F(VersionTest, InvalidEdit) {
     auto add1_1_3 = AddBlobFilesEdit(1, 1, 3);
     EditCollector collector;
     ASSERT_OK(collector.AddEdit(add1_1_3));
-    ASSERT_NOK(collector.Check(*vset_.get()));
+    ASSERT_NOK(collector.Seal(*vset_.get()));
     ASSERT_NOK(collector.Apply(*vset_.get()));
   }
 
@@ -177,7 +177,7 @@ TEST_F(VersionTest, InvalidEdit) {
     EditCollector collector;
     ASSERT_OK(collector.AddEdit(add1_4_5_1));
     ASSERT_NOK(collector.AddEdit(add1_4_5_2));
-    ASSERT_NOK(collector.Check(*vset_.get()));
+    ASSERT_NOK(collector.Seal(*vset_.get()));
     ASSERT_NOK(collector.Apply(*vset_.get()));
   }
 
@@ -188,7 +188,7 @@ TEST_F(VersionTest, InvalidEdit) {
     EditCollector collector;
     ASSERT_OK(collector.AddEdit(del1_3_4_1));
     ASSERT_NOK(collector.AddEdit(del1_3_4_2));
-    ASSERT_NOK(collector.Check(*vset_.get()));
+    ASSERT_NOK(collector.Seal(*vset_.get()));
     ASSERT_NOK(collector.Apply(*vset_.get()));
   }
 }


### PR DESCRIPTION
Now we check edit validity after written to manifest. That is to say, if the validity check does not pass for some edits, then the restart of Titan would always fail because the invalid edits are already written to manifest.