### PR TITLE
Schedule GC to bottom priority pool

### DIFF
--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -224,15 +224,15 @@ Status TitanDBImpl::Open(const std::vector<TitanCFDescriptor>& descs,
 
   static bool has_init_background_threads = false;
   if (!has_init_background_threads) {
-    auto low_pri_threads_num = env_->GetBackgroundThreads(Env::Priority::LOW);
-    assert(low_pri_threads_num > 0);
+    auto bottom_pri_threads_num =
+        env_->GetBackgroundThreads(Env::Priority::BOTTOM);
     if (!db_options_.disable_background_gc &&
         db_options_.max_background_gc > 0) {
       env_->IncBackgroundThreadsIfNeeded(
-          db_options_.max_background_gc + low_pri_threads_num,
-          Env::Priority::LOW);
-      assert(env_->GetBackgroundThreads(Env::Priority::LOW) ==
-             low_pri_threads_num + db_options_.max_background_gc);
+          db_options_.max_background_gc + bottom_pri_threads_num,
+          Env::Priority::BOTTOM);
+      assert(env_->GetBackgroundThreads(Env::Priority::BOTTOM) ==
+             bottom_pri_threads_num + db_options_.max_background_gc);
     }
     has_init_background_threads = true;
   }
@@ -286,7 +286,7 @@ Status TitanDBImpl::CloseImpl() {
     shuting_down_.store(true, std::memory_order_release);
   }
 
-  int gc_unscheduled = env_->UnSchedule(this, Env::Priority::LOW);
+  int gc_unscheduled = env_->UnSchedule(this, Env::Priority::BOTTOM);
   {
     MutexLock l(&mutex_);
     bg_gc_scheduled_ -= gc_unscheduled;

--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -53,7 +53,7 @@ void TitanDBImpl::BackgroundCallGC() {
     }
     // IMPORTANT: there should be no code after calling SignalAll. This call may
     // signal the DB destructor that it's OK to proceed with destruction. In
-    // that case, all DB variables will be dealloacated and referencing them
+    // that case, all DB variables will be deallocated and referencing them
     // will cause trouble.
   }
 }

--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -20,7 +20,7 @@ void TitanDBImpl::MaybeScheduleGC() {
 
   bg_gc_scheduled_.fetch_add(1, std::memory_order_release);
 
-  env_->Schedule(&TitanDBImpl::BGWorkGC, this, Env::Priority::LOW, this);
+  env_->Schedule(&TitanDBImpl::BGWorkGC, this, Env::Priority::BOTTOM, this);
 }
 
 void TitanDBImpl::BGWorkGC(void* db) {


### PR DESCRIPTION
Schedule GC tasks to bottom priority thread pool so that we can distinguish them from compaction jobs which are in low priority pool.