### PR TITLE
Replace atomic var by normal var

### DIFF
--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -200,7 +200,7 @@ class TitanDBImpl : public TitanDB {
   // gc_queue_ hold column families that we need to gc.
   // pending_gc_ hold column families that already on gc_queue_.
   std::deque<uint32_t> gc_queue_;
-  
+
   // Guarded by mutex_.
   int bg_gc_scheduled_{0};
 

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -201,7 +201,7 @@ class TitanDBImpl : public TitanDB {
   // pending_gc_ hold column families that already on gc_queue_.
   std::deque<uint32_t> gc_queue_;
 
-  std::atomic_int bg_gc_scheduled_{0};
+  int bg_gc_scheduled_{0};
 
   std::atomic_bool shuting_down_{false};
 };

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -200,7 +200,8 @@ class TitanDBImpl : public TitanDB {
   // gc_queue_ hold column families that we need to gc.
   // pending_gc_ hold column families that already on gc_queue_.
   std::deque<uint32_t> gc_queue_;
-
+  
+  // Guarded by mutex_.
   int bg_gc_scheduled_{0};
 
   std::atomic_bool shuting_down_{false};

--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -14,11 +14,10 @@ void TitanDBImpl::MaybeScheduleGC() {
 
   if (shuting_down_.load(std::memory_order_acquire)) return;
 
-  if (bg_gc_scheduled_.load(std::memory_order_acquire) >=
-      db_options_.max_background_gc)
+  if (bg_gc_scheduled_ >= db_options_.max_background_gc)
     return;
 
-  bg_gc_scheduled_.fetch_add(1, std::memory_order_release);
+  bg_gc_scheduled_++;
 
   env_->Schedule(&TitanDBImpl::BGWorkGC, this, Env::Priority::LOW, this);
 }
@@ -118,7 +117,7 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer) {
 Status TitanDBImpl::TEST_StartGC(uint32_t column_family_id) {
   {
     MutexLock l(&mutex_);
-    bg_gc_scheduled_.fetch_add(1, std::memory_order_release);
+    bg_gc_scheduled_++;
   }
   // BackgroundCallGC
   Status s;

--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -14,8 +14,7 @@ void TitanDBImpl::MaybeScheduleGC() {
 
   if (shuting_down_.load(std::memory_order_acquire)) return;
 
-  if (bg_gc_scheduled_ >= db_options_.max_background_gc)
-    return;
+  if (bg_gc_scheduled_ >= db_options_.max_background_gc) return;
 
   bg_gc_scheduled_++;
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -69,8 +69,7 @@ Slice Compress(const CompressionContext& ctx, const Slice& input,
         return *output;
       }
       break;
-    default: {
-    }  // Do not recognize this compression type
+    default: {}  // Do not recognize this compression type
   }
 
   // Compression method is not supported, or not good compression

--- a/src/util.cc
+++ b/src/util.cc
@@ -69,7 +69,8 @@ Slice Compress(const CompressionContext& ctx, const Slice& input,
         return *output;
       }
       break;
-    default: {}  // Do not recognize this compression type
+    default: {
+    }  // Do not recognize this compression type
   }
 
   // Compression method is not supported, or not good compression


### PR DESCRIPTION
Because db is locked when  add/sub  bg_gc_scheduled_, so this variable is no need to be atomic 