### PR TITLE
Turn titan into read-only on error during gc and version_change

### DIFF
--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -871,5 +871,24 @@ void TitanDBImpl::OnCompactionCompleted(
   }
 }
 
+Status TitanDBImpl::SetBGError(const Status& s) {
+  if (s.ok()) return s;
+  mutex_.AssertHeld();
+  Status bg_err = s;
+  if (!db_options_.listeners.empty()) {
+    // TODO(@jiayu) : check if mutex_ is freeable for future use case
+    mutex_.Unlock();
+    for (auto& listener : db_options_.listeners) {
+      listener->OnBackgroundError(BackgroundErrorReason::kCompaction, &bg_err);
+    }
+    mutex_.Lock();
+  }
+  if (!bg_err.ok()) {
+    bg_error_ = bg_err;
+    has_bg_error_.store(true);
+  }
+  return bg_err;
+}
+
 }  // namespace titandb
 }  // namespace rocksdb

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -441,6 +441,47 @@ Status TitanDBImpl::CompactFiles(
   return s;
 }
 
+Status TitanDBImpl::Put(const rocksdb::WriteOptions& options,
+                        rocksdb::ColumnFamilyHandle* column_family,
+                        const rocksdb::Slice& key,
+                        const rocksdb::Slice& value) {
+  return HasBGError() ? GetBGError()
+                      : db_->Put(options, column_family, key, value);
+}
+
+Status TitanDBImpl::Write(const rocksdb::WriteOptions& options,
+                          rocksdb::WriteBatch* updates) {
+  return HasBGError() ? GetBGError() : db_->Write(options, updates);
+}
+
+Status TitanDBImpl::Delete(const rocksdb::WriteOptions& options,
+                           rocksdb::ColumnFamilyHandle* column_family,
+                           const rocksdb::Slice& key) {
+  return HasBGError() ? GetBGError() : db_->Delete(options, column_family, key);
+}
+
+Status TitanDBImpl::IngestExternalFile(
+    rocksdb::ColumnFamilyHandle* column_family,
+    const std::vector<std::string>& external_files,
+    const rocksdb::IngestExternalFileOptions& options) {
+  return HasBGError()
+             ? GetBGError()
+             : db_->IngestExternalFile(column_family, external_files, options);
+}
+
+Status TitanDBImpl::CompactRange(const rocksdb::CompactRangeOptions& options,
+                                 rocksdb::ColumnFamilyHandle* column_family,
+                                 const rocksdb::Slice* begin,
+                                 const rocksdb::Slice* end) {
+  return HasBGError() ? GetBGError()
+                      : db_->CompactRange(options, column_family, begin, end);
+}
+
+Status TitanDBImpl::Flush(const rocksdb::FlushOptions& options,
+                          rocksdb::ColumnFamilyHandle* column_family) {
+  return HasBGError() ? GetBGError() : db_->Flush(options, column_family);
+}
+
 Status TitanDBImpl::Get(const ReadOptions& options, ColumnFamilyHandle* handle,
                         const Slice& key, PinnableSlice* value) {
   if (options.snapshot) {

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -73,6 +73,9 @@ class TitanDBImpl::FileManager : public BlobFileManager {
     {
       MutexLock l(&db_->mutex_);
       s = db_->vset_->LogAndApply(edit);
+      if (!s.ok()) {
+        db_->SetBGError(s);
+      }
       for (const auto& file : files)
         db_->pending_outputs_.erase(file.second->GetNumber());
     }
@@ -422,6 +425,7 @@ Status TitanDBImpl::CompactFiles(
     const std::vector<std::string>& input_file_names, const int output_level,
     const int output_path_id, std::vector<std::string>* const output_file_names,
     CompactionJobInfo* compaction_job_info) {
+  if (HasBGError()) return GetBGError();
   std::unique_ptr<CompactionJobInfo> compaction_job_info_ptr;
   if (compaction_job_info == nullptr) {
     compaction_job_info_ptr.reset(new CompactionJobInfo());

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -45,44 +45,28 @@ class TitanDBImpl : public TitanDB {
 
   using TitanDB::Put;
   Status Put(const WriteOptions& options, ColumnFamilyHandle* column_family,
-             const Slice& key, const Slice& val) override {
-    return HasBGError() ? GetBGError()
-                        : db_->Put(options, column_family, key, val);
-  }
+             const Slice& key, const Slice& value) override;
 
   using TitanDB::Write;
-  Status Write(const WriteOptions& opts, WriteBatch* updates) override {
-    return HasBGError() ? GetBGError() : db_->Write(opts, updates);
-  }
+  Status Write(const WriteOptions& options, WriteBatch* updates) override;
 
   using TitanDB::Delete;
-  Status Delete(const WriteOptions& wopts, ColumnFamilyHandle* column_family,
-                const Slice& key) override {
-    return HasBGError() ? GetBGError() : db_->Delete(wopts, column_family, key);
-  }
+  Status Delete(const WriteOptions& options, ColumnFamilyHandle* column_family,
+                const Slice& key) override;
 
   using TitanDB::IngestExternalFile;
   Status IngestExternalFile(ColumnFamilyHandle* column_family,
                             const std::vector<std::string>& external_files,
-                            const IngestExternalFileOptions& options) override {
-    return HasBGError() ? GetBGError()
-                        : db_->IngestExternalFile(column_family, external_files,
-                                                  options);
-  }
+                            const IngestExternalFileOptions& options) override;
 
   using TitanDB::CompactRange;
   Status CompactRange(const CompactRangeOptions& options,
                       ColumnFamilyHandle* column_family, const Slice* begin,
-                      const Slice* end) override {
-    return HasBGError() ? GetBGError()
-                        : db_->CompactRange(options, column_family, begin, end);
-  }
+                      const Slice* end) override;
 
   using TitanDB::Flush;
   Status Flush(const FlushOptions& fopts,
-               ColumnFamilyHandle* column_family) override {
-    return HasBGError() ? GetBGError() : db_->Flush(fopts, column_family);
-  }
+               ColumnFamilyHandle* column_family) override;
 
   using TitanDB::Get;
   Status Get(const ReadOptions& options, ColumnFamilyHandle* handle,

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -46,7 +46,8 @@ class TitanDBImpl : public TitanDB {
   using TitanDB::Put;
   Status Put(const WriteOptions& options, ColumnFamilyHandle* column_family,
              const Slice& key, const Slice& val) override {
-    return HasBGError() ? GetBGError() : db_->Put(options, column_family, key, val);
+    return HasBGError() ? GetBGError()
+                        : db_->Put(options, column_family, key, val);
   }
 
   using TitanDB::Write;
@@ -65,7 +66,8 @@ class TitanDBImpl : public TitanDB {
                             const std::vector<std::string>& external_files,
                             const IngestExternalFileOptions& options) override {
     return HasBGError() ? GetBGError()
-                        : db_->IngestExternalFile(column_family, external_files, options);
+                        : db_->IngestExternalFile(column_family, external_files,
+                                                  options);
   }
 
   using TitanDB::CompactRange;

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -196,6 +196,7 @@ class TitanDBImpl : public TitanDB {
     return oldest_snapshot;
   }
 
+  // REQUIRE: mutex_ held
   Status SetBGError(const Status& s);
 
   Status GetBGError() {

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -2,7 +2,6 @@
 
 #include "blob_file_manager.h"
 #include "db/db_impl.h"
-#include "iostream"
 #include "rocksdb/statistics.h"
 #include "table_factory.h"
 #include "titan/db.h"
@@ -47,8 +46,7 @@ class TitanDBImpl : public TitanDB {
   using TitanDB::Put;
   Status Put(const WriteOptions& options, ColumnFamilyHandle* column_family,
              const Slice& key, const Slice& val) override {
-    return HasBGError() ? GetBGError()
-                        : db_->Put(options, column_family, key, val);
+    return HasBGError() ? GetBGError() : db_->Put(options, column_family, key, val);
   }
 
   using TitanDB::Write;
@@ -67,8 +65,7 @@ class TitanDBImpl : public TitanDB {
                             const std::vector<std::string>& external_files,
                             const IngestExternalFileOptions& options) override {
     return HasBGError() ? GetBGError()
-                        : db_->IngestExternalFile(column_family, external_files,
-                                                  options);
+                        : db_->IngestExternalFile(column_family, external_files, options);
   }
 
   using TitanDB::CompactRange;
@@ -223,7 +220,7 @@ class TitanDBImpl : public TitanDB {
   DBImpl* db_impl_;
   TitanDBOptions db_options_;
   // Turn DB into read-only if background happened
-  Status bg_error_{};
+  Status bg_error_;
   std::atomic_bool has_bg_error_{false};
 
   // TitanStats is turned on only if statistics field of DBOptions

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -221,7 +221,7 @@ class TitanDBImpl : public TitanDB {
   EnvOptions env_options_;
   DBImpl* db_impl_;
   TitanDBOptions db_options_;
-  // Turn DB into read-only if background happened
+  // Turn DB into read-only if background error happened
   Status bg_error_;
   std::atomic_bool has_bg_error_{false};
 

--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -115,25 +115,6 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer) {
   return s;
 }
 
-Status TitanDBImpl::SetBGError(const Status& s) {
-  if (s.ok()) return s;
-  mutex_.AssertHeld();
-  Status bg_err = s;
-  if (!db_options_.listeners.empty()) {
-    // TODO(@jiayu) : check if mutex_ is freeable for futrue use case
-    mutex_.Unlock();
-    for (auto& listener : db_options_.listeners) {
-      listener->OnBackgroundError(BackgroundErrorReason::kCompaction, &bg_err);
-    }
-    mutex_.Lock();
-  }
-  if (!bg_err.ok()) {
-    bg_error_ = bg_err;
-    has_bg_error_.store(true);
-  }
-  return bg_err;
-}
-
 Status TitanDBImpl::TEST_StartGC(uint32_t column_family_id) {
   {
     MutexLock l(&mutex_);

--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -65,7 +65,6 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer) {
   std::unique_ptr<BlobGC> blob_gc;
   std::unique_ptr<ColumnFamilyHandle> cfh;
   Status s;
-
   if (!gc_queue_.empty()) {
     uint32_t column_family_id = PopFirstFromGCQueue();
     auto bs = vset_->GetBlobStorage(column_family_id).lock().get();

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -775,12 +775,13 @@ TEST_F(TitanDBTest, FallbackModeEncounterMissingBlobFile) {
 TEST_F(TitanDBTest, BackgroundErrorHandling) {
   options_.listeners.emplace_back(std::make_shared<BGErrorListener>());
   Open();
-  std::string key = "key", val;
+  std::string key = "key", val = "val";
   SetBGError(Status::IOError(""));
   // BG error is restored by listener for first time
   ASSERT_OK(db_->Put(WriteOptions(), key, val));
   SetBGError(Status::IOError(""));
   ASSERT_OK(db_->Get(ReadOptions(), key, &val));
+  ASSERT_EQ(val, "val");
   ASSERT_TRUE(db_->Put(WriteOptions(), key, val).IsIOError());
   ASSERT_TRUE(db_->Flush(FlushOptions()).IsIOError());
   ASSERT_TRUE(db_->Delete(WriteOptions(), key).IsIOError());

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -225,30 +225,52 @@ class TitanDBTest : public testing::Test {
     DeleteDir(env_, dbname_);
   }
 
-  void BackgroundErrorHandling() {
-    options_.listeners.emplace_back(std::make_shared<BGErrorListener>());
+  void BackgroundErrorTrigger() {
+    std::unique_ptr<TitanFaultInjectionTestEnv> mock_env(
+        new TitanFaultInjectionTestEnv(env_));
+    options_.env = mock_env.get();
     Open();
     std::map<std::string, std::string> data;
     const int kNumEntries = 100;
     for (uint64_t i = 1; i <= kNumEntries; i++) {
       Put(i, &data);
     }
-    WriteOptions wops;
-    FlushOptions fops;
-    CompactionOptions cops;
-    CompactRangeOptions crops;
+    Flush();
+    ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+    SyncPoint::GetInstance()->SetCallBack(
+        "VersionSet::LogAndApply", [&](void*) {
+          mock_env->SetFilesystemActive(false,
+                                        Status::IOError("Injected error"));
+        });
+    SyncPoint::GetInstance()->EnableProcessing();
+    db_impl_->bg_gc_scheduled_++;
+    db_impl_->BackgroundCallGC();
+    while (db_impl_->bg_gc_scheduled_)
+      ;
+    ASSERT_TRUE(db_impl_->HasBGError());
+    mock_env->SetFilesystemActive(true);
+    // Still failed for bg error
+    ASSERT_TRUE(db_impl_->Put(WriteOptions(), "key", "val").IsIOError());
+    Close();
+  }
+
+  void BackgroundErrorHandling() {
+    options_.listeners.emplace_back(std::make_shared<BGErrorListener>());
+    Open();
     std::string key = "key", val;
     SetBGError(Status::IOError(""));
     // BG error is restored by listener for first time
-    ASSERT_OK(db_->Put(wops, key, val));
+    ASSERT_OK(db_->Put(WriteOptions(), key, val));
     SetBGError(Status::IOError(""));
     ASSERT_OK(db_->Get(ReadOptions(), key, &val));
-    ASSERT_TRUE(db_->Put(wops, key, val).IsIOError());
-    ASSERT_TRUE(db_->Flush(fops).IsIOError());
-    ASSERT_TRUE(db_->Delete(wops, key).IsIOError());
-    ASSERT_TRUE(db_->CompactRange(crops, nullptr, nullptr).IsIOError());
+    ASSERT_TRUE(db_->Put(WriteOptions(), key, val).IsIOError());
+    ASSERT_TRUE(db_->Flush(FlushOptions()).IsIOError());
+    ASSERT_TRUE(db_->Delete(WriteOptions(), key).IsIOError());
     ASSERT_TRUE(
-        db_->CompactFiles(cops, std::vector<std::string>(), 1).IsIOError());
+        db_->CompactRange(CompactRangeOptions(), nullptr, nullptr).IsIOError());
+    ASSERT_TRUE(
+        db_->CompactFiles(CompactionOptions(), std::vector<std::string>(), 1).IsIOError());
+    Close();
   }
 
   void SetBGError(const Status& s) {
@@ -256,6 +278,7 @@ class TitanDBTest : public testing::Test {
     db_impl_->SetBGError(s);
   }
 
+  // Make db ignore first bg_error
   class BGErrorListener : public EventListener {
    public:
     void OnBackgroundError(BackgroundErrorReason reason,
@@ -791,6 +814,7 @@ TEST_F(TitanDBTest, FallbackModeEncounterMissingBlobFile) {
 }
 
 TEST_F(TitanDBTest, BackgroundErrorHandling) { BackgroundErrorHandling(); }
+TEST_F(TitanDBTest, BackgroundErrorTrigger) { BackgroundErrorTrigger(); }
 
 }  // namespace titandb
 }  // namespace rocksdb

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -269,7 +269,8 @@ class TitanDBTest : public testing::Test {
     ASSERT_TRUE(
         db_->CompactRange(CompactRangeOptions(), nullptr, nullptr).IsIOError());
     ASSERT_TRUE(
-        db_->CompactFiles(CompactionOptions(), std::vector<std::string>(), 1).IsIOError());
+        db_->CompactFiles(CompactionOptions(), std::vector<std::string>(), 1)
+            .IsIOError());
     Close();
   }
 

--- a/src/version_set.cc
+++ b/src/version_set.cc
@@ -204,6 +204,7 @@ Status VersionSet::WriteSnapshot(log::Writer* log) {
 }
 
 Status VersionSet::LogAndApply(VersionEdit& edit) {
+  TEST_SYNC_POINT("VersionSet::LogAndApply");
   // TODO(@huachao): write manifest file unlocked
   std::string record;
   edit.SetNextFileNumber(next_file_number_.load());

--- a/src/version_set.cc
+++ b/src/version_set.cc
@@ -213,11 +213,12 @@ Status VersionSet::LogAndApply(VersionEdit& edit) {
     ImmutableDBOptions ioptions(db_options_);
     s = SyncManifest(env_, &ioptions, manifest_->file());
   }
-  if (!s.ok()) return s;
-
-  EditCollector collector;
-  collector.AddEdit(edit);
-  return collector.Apply(*this);
+  if (s.ok()) {
+    EditCollector collector;
+    collector.AddEdit(edit);
+    s = collector.Apply(*this);
+  }
+  return s;
 }
 
 void VersionSet::AddColumnFamilies(


### PR DESCRIPTION
- Set background error if encountered a critical error. Now it's set for two cases
    - BackgroundGC() error
    - LogAndApply() error after generate new blob file
- If background error is set, all following foreground write operations will be refused and return background error status