### PR TITLE
Fix blob file iterator

### DIFF
--- a/src/blob_file_iterator.cc
+++ b/src/blob_file_iterator.cc
@@ -96,7 +96,7 @@ void BlobFileIterator::GetBlobRecord() {
 
   Slice record_slice;
   auto record_size = decoder_.GetRecordSize();
-  buffer_.reserve(record_size);
+  buffer_.resize(record_size);
   status_ = file_->Read(iterate_offset_ + kBlobHeaderSize, record_size,
                         &record_slice, buffer_.data());
   if (status_.ok()) {
@@ -167,11 +167,15 @@ void BlobFileMergeIterator::SeekToFirst() {
 }
 
 void BlobFileMergeIterator::Next() {
-  assert(current_ != nullptr);
+  assert(Valid());
   current_->Next();
   if (current_->status().ok() && current_->Valid()) min_heap_.push(current_);
-  current_ = min_heap_.top();
-  min_heap_.pop();
+  if (!min_heap_.empty()) {
+      current_ = min_heap_.top();
+      min_heap_.pop();
+  } else {
+      current_ = nullptr;
+  }
 }
 
 Slice BlobFileMergeIterator::key() const {

--- a/src/blob_file_iterator.cc
+++ b/src/blob_file_iterator.cc
@@ -171,10 +171,10 @@ void BlobFileMergeIterator::Next() {
   current_->Next();
   if (current_->status().ok() && current_->Valid()) min_heap_.push(current_);
   if (!min_heap_.empty()) {
-      current_ = min_heap_.top();
-      min_heap_.pop();
+    current_ = min_heap_.top();
+    min_heap_.pop();
   } else {
-      current_ = nullptr;
+    current_ = nullptr;
   }
 }
 

--- a/src/blob_file_iterator_test.cc
+++ b/src/blob_file_iterator_test.cc
@@ -209,6 +209,7 @@ TEST_F(BlobFileIteratorTest, MergeIterator) {
   BlobFileMergeIterator iter(std::move(iters));
 
   iter.SeekToFirst();
+  int i = 1;
   for (;iter.Valid(); i++, iter.Next()) {
     ASSERT_OK(iter.status());
     ASSERT_TRUE(iter.Valid());

--- a/src/blob_file_iterator_test.cc
+++ b/src/blob_file_iterator_test.cc
@@ -209,13 +209,14 @@ TEST_F(BlobFileIteratorTest, MergeIterator) {
   BlobFileMergeIterator iter(std::move(iters));
 
   iter.SeekToFirst();
-  for (int i = 1; i < kMaxKeyNum; i++, iter.Next()) {
+  for (;iter.Valid(); i++, iter.Next()) {
     ASSERT_OK(iter.status());
     ASSERT_TRUE(iter.Valid());
     ASSERT_EQ(iter.key(), GenKey(i));
     ASSERT_EQ(iter.value(), GenValue(i));
     ASSERT_EQ(iter.GetBlobIndex().blob_handle, handles[i]);
   }
+  ASSERT_EQ(i, kMaxKeyNum);
 }
 
 }  // namespace titandb

--- a/src/blob_file_iterator_test.cc
+++ b/src/blob_file_iterator_test.cc
@@ -210,7 +210,7 @@ TEST_F(BlobFileIteratorTest, MergeIterator) {
 
   iter.SeekToFirst();
   int i = 1;
-  for (;iter.Valid(); i++, iter.Next()) {
+  for (; iter.Valid(); i++, iter.Next()) {
     ASSERT_OK(iter.status());
     ASSERT_TRUE(iter.Valid());
     ASSERT_EQ(iter.key(), GenKey(i));


### PR DESCRIPTION
Fixed a container overflow bug in blob_file_iterator.cc, witch will corrupt data and fail tests on MacOS.