### PR TITLE
Change raw ptr in BlobGC to shared_ptr

### DIFF
--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -475,7 +475,7 @@ Status BlobGCJob::InstallOutputBlobFiles() {
           builder.first->GetNumber(), builder.first->GetFile()->GetFileSize());
 
       if (!tmp.empty()) {
-        tmp.append("");
+        tmp.append(" ");
       }
       tmp.append(std::to_string(file->file_number()));
       // To temporarily hold the ptr of BlobFileMeta
@@ -484,7 +484,7 @@ Status BlobGCJob::InstallOutputBlobFiles() {
       tmp_file_metas.push_back(file);
       files.emplace_back(std::make_pair(file, std::move(builder.first)));
     }
-    ROCKS_LOG_BUFFER(log_buffer_, "[%s]output[%s]",
+    ROCKS_LOG_BUFFER(log_buffer_, "[%s] output[%s]",
                      blob_gc_->column_family_handle()->GetName().c_str(),
                      tmp.c_str());
     s = this->blob_file_manager_->BatchFinishFiles(


### PR DESCRIPTION
**Problem**: I find that titan_db_test failed at the BackgroundErrorTrigger case with ASAN ON under the trigger_next pr 
**Cause**: After debugging I find that in the BlobGCJob::InstallOutputFiles, BlobFileMeta was generated as shared_ptr, but add to BlobGCJoB::outputs_ as raw_ptr( by shared_ptr::get()). When writing to manifest failed in the BatchFinishFiles, shared_ptr of BlobFileMeta may be released and the access of raw pointer hold by outputs_ may cause error(use memory had been free)
**Fix**: I make the input_, output_ and sampled_input in BlobGCJon from raw_ptr to shared_ptr and modified  related interface
**Note**: This problem was find from another pr(trigger next), it maybe caused by adding small file to BlobGC directly, and master branch can pass the titan_db_test, so I am not sure whether this fix is necessary(even so I think we'd better not take raw_ptr from shared_ptr)