### PR TITLE
limit GC IO with rate_limiter

### DIFF
--- a/src/blob_file_reader.cc
+++ b/src/blob_file_reader.cc
@@ -28,7 +28,7 @@ Status NewBlobFileReader(uint64_t file_number, uint64_t readahead_size,
   if (readahead_size > 0) {
     file = NewReadaheadRandomAccessFile(std::move(file), readahead_size);
   }
-  result->reset(new RandomAccessFileReader(std::move(file), file_name));
+  result->reset(new RandomAccessFileReader(std::move(file), file_name, nullptr, nullptr, 0, nullptr, env_options.rate_limiter, true));
   return s;
 }
 


### PR DESCRIPTION
Limit GC and Titan read IO with rate_limiter, to avoid burst of IO starve online workloads.

PS: blob-file-writer already inherited rate_limiter from env_options.