### PR TITLE
Add internal operation stats and dump to info log periodically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ if (WITH_TITAN_TESTS AND (NOT CMAKE_BUILD_TYPE STREQUAL "Release"))
         table_builder_test
         thread_safety_test
         titan_db_test
+        titan_options_test
         util_test
         version_test)
   set(TEST_LIBS

--- a/include/titan/options.h
+++ b/include/titan/options.h
@@ -29,7 +29,13 @@ struct TitanDBOptions : public DBOptions {
   // How often to schedule delete obsolete blob files periods
   //
   // Default: 10
-  uint32_t purge_obsolete_files_period{10};  // 10s
+  uint32_t purge_obsolete_files_period_sec{10};  // 10s
+
+  // If non-zero, dump titan internal stats to info log every
+  // titan_stats_dump_period_sec.
+  //
+  // Default: 600 (10 min)
+  uint32_t titan_stats_dump_period_sec{600};
 
   TitanDBOptions() = default;
   explicit TitanDBOptions(const DBOptions& options) : DBOptions(options) {}

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -27,6 +27,8 @@ struct BlobRecord {
   void EncodeTo(std::string* dst) const;
   Status DecodeFrom(Slice* src);
 
+  size_t size() const { return key.size() + value.size(); }
+
   friend bool operator==(const BlobRecord& lhs, const BlobRecord& rhs);
 };
 

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -600,7 +600,6 @@ void BlobGCJob::UpdateInternalOpStats() {
   if (internal_stats == nullptr) {
     return;
   }
-  InternalOpType op_type = InternalOpType::GC;
   InternalOpStats* internal_op_stats =
       internal_stats->GetInternalOpStatsForType(InternalOpType::GC);
   assert(internal_op_stats != nullptr);

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -615,7 +615,7 @@ void BlobGCJob::UpdateInternalOpStats() {
            io_bytes_written_);
   AddStats(internal_op_stats, InternalOpStatsType::INPUT_FILE_NUM,
            metrics_.blob_db_gc_num_files);
-  AddStats(internal_op_stats, InternalOpStatsType::INPUT_FILE_NUM,
+  AddStats(internal_op_stats, InternalOpStatsType::OUTPUT_FILE_NUM,
            metrics_.blob_db_gc_num_new_files);
 }
 

--- a/src/blob_gc_job.h
+++ b/src/blob_gc_job.h
@@ -40,6 +40,8 @@ class BlobGCJob {
   class GarbageCollectionWriteCallback;
   friend class BlobGCJobTest;
 
+  void UpdateInternalOpStats();
+
   BlobGC* blob_gc_;
   DB* base_db_;
   DBImpl* base_db_impl_;
@@ -71,6 +73,11 @@ class BlobGCJob {
     uint64_t blob_db_gc_num_new_files = 0;
     uint64_t blob_db_gc_num_files = 0;
   } metrics_;
+
+  uint64_t prev_bytes_read_ = 0;
+  uint64_t prev_bytes_written_ = 0;
+  uint64_t io_bytes_read_ = 0;
+  uint64_t io_bytes_written_ = 0;
 
   Status SampleCandidateFiles();
   Status DoSample(const BlobFileMeta* file, bool* selected);

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -156,10 +156,22 @@ void TitanDBImpl::StartBackgroundTasks() {
   }
 }
 
+Status TitanDBImpl::ValidateOptions() const {
+  if (db_options_.purge_obsolete_files_period_sec == 0) {
+    return Status::InvalidArgument(
+        "Require non-zero purge_obsolete_files_period_sec");
+  }
+  return Status::OK();
+}
+
 Status TitanDBImpl::Open(const std::vector<TitanCFDescriptor>& descs,
                          std::vector<ColumnFamilyHandle*>* handles) {
+  Status s = ValidateOptions();
+  if (!s.ok()) {
+    return s;
+  }
   // Sets up directories for base DB and Titan.
-  Status s = env_->CreateDirIfMissing(dbname_);
+  s = env_->CreateDirIfMissing(dbname_);
   if (!s.ok()) return s;
   if (!db_options_.info_log) {
     s = CreateLoggerFromOptions(dbname_, db_options_, &db_options_.info_log);

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -11,6 +11,14 @@
 namespace rocksdb {
 namespace titandb {
 
+struct TitanColumnFamilyInfo {
+  const std::string name;
+  const ImmutableTitanCFOptions immutable_cf_options;
+  MutableTitanCFOptions mutable_cf_options;
+  std::shared_ptr<TableFactory> base_table_factory;
+  std::shared_ptr<TitanTableFactory> titan_table_factory;
+};
+
 class TitanDBImpl : public TitanDB {
  public:
   TitanDBImpl(const TitanDBOptions& options, const std::string& dbname);
@@ -220,19 +228,8 @@ class TitanDBImpl : public TitanDB {
   // is not null.
   std::unique_ptr<TitanStats> stats_;
 
-  // Guarded by mutex_.
-  std::unordered_map<uint32_t, ImmutableTitanCFOptions> immutable_cf_options_;
-
-  // Guarded by mutex_.
-  std::unordered_map<uint32_t, MutableTitanCFOptions> mutable_cf_options_;
-
-  // Guarded by mutex_.
-  std::unordered_map<uint32_t, std::shared_ptr<TableFactory>>
-      base_table_factory_;
-
-  // Guarded by mutex_.
-  std::unordered_map<uint32_t, std::shared_ptr<TitanTableFactory>>
-      titan_table_factory_;
+  // Access while holding mutex_ lock or during DB open.
+  std::unordered_map<uint32_t, TitanColumnFamilyInfo> cf_info_;
 
   // handle for purging obsolete blob files at fixed intervals
   std::unique_ptr<RepeatableThread> thread_purge_obsolete_;

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -145,6 +145,8 @@ class TitanDBImpl : public TitanDB {
   friend class TitanDBTest;
   friend class TitanThreadSafetyTest;
 
+  Status ValidateOptions() const;
+
   Status GetImpl(const ReadOptions& options, ColumnFamilyHandle* handle,
                  const Slice& key, PinnableSlice* value);
 

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -204,6 +204,8 @@ class TitanDBImpl : public TitanDB {
 
   bool HasBGError() { return has_bg_error_.load(); }
 
+  void DumpStats();
+
   FileLock* lock_{nullptr};
   // The lock sequence must be Titan.mutex_.Lock() -> Base DB mutex_.Lock()
   // while the unlock sequence must be Base DB mutex.Unlock() ->
@@ -233,6 +235,9 @@ class TitanDBImpl : public TitanDB {
 
   // handle for purging obsolete blob files at fixed intervals
   std::unique_ptr<RepeatableThread> thread_purge_obsolete_;
+
+  // handle for dump internal stats at fixed intervals.
+  std::unique_ptr<RepeatableThread> thread_dump_stats_;
 
   std::unique_ptr<VersionSet> vset_;
   std::set<uint64_t> pending_outputs_;

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -1,11 +1,13 @@
 #pragma once
 
-#include "blob_file_manager.h"
 #include "db/db_impl/db_impl.h"
 #include "rocksdb/statistics.h"
+#include "util/repeatable_thread.h"
+
+#include "blob_file_manager.h"
 #include "table_factory.h"
 #include "titan/db.h"
-#include "util/repeatable_thread.h"
+#include "titan_stats.h"
 #include "version_set.h"
 
 namespace rocksdb {

--- a/src/options.cc
+++ b/src/options.cc
@@ -22,8 +22,11 @@ void TitanDBOptions::Dump(Logger* logger) const {
                    "TitanDBOptions.max_background_gc          : %" PRIi32,
                    max_background_gc);
   ROCKS_LOG_HEADER(logger,
-                   "TitanDBOptions.purge_obsolete_files_period: %" PRIu32,
-                   purge_obsolete_files_period);
+                   "TitanDBOptions.purge_obsolete_files_period_sec: %" PRIu32,
+                   purge_obsolete_files_period_sec);
+  ROCKS_LOG_HEADER(logger,
+                   "TitanDBOptions.titan_stats_dump_period_sec: %" PRIu32,
+                   titan_stats_dump_period_sec);
 }
 
 TitanCFOptions::TitanCFOptions(const ColumnFamilyOptions& cf_opts,

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -16,13 +16,15 @@ class TitanTableBuilder : public TableBuilder {
                     const TitanCFOptions& cf_options,
                     std::unique_ptr<TableBuilder> base_builder,
                     std::shared_ptr<BlobFileManager> blob_manager,
-                    std::weak_ptr<BlobStorage> blob_storage, TitanStats* stats)
+                    std::weak_ptr<BlobStorage> blob_storage, int level,
+                    TitanStats* stats)
       : cf_id_(cf_id),
         db_options_(db_options),
         cf_options_(cf_options),
         base_builder_(std::move(base_builder)),
         blob_manager_(blob_manager),
         blob_storage_(blob_storage),
+        level_(level),
         stats_(stats) {}
 
   void Add(const Slice& key, const Slice& value) override;
@@ -46,6 +48,8 @@ class TitanTableBuilder : public TableBuilder {
 
   void AddBlob(const Slice& key, const Slice& value, std::string* index_value);
 
+  void UpdateInternalOpStats();
+
   Status status_;
   uint32_t cf_id_;
   TitanDBOptions db_options_;
@@ -55,8 +59,14 @@ class TitanTableBuilder : public TableBuilder {
   std::shared_ptr<BlobFileManager> blob_manager_;
   std::unique_ptr<BlobFileBuilder> blob_builder_;
   std::weak_ptr<BlobStorage> blob_storage_;
-
+  int level_;
   TitanStats* stats_;
+
+  // counters
+  uint64_t bytes_read_ = 0;
+  uint64_t bytes_written_ = 0;
+  uint64_t io_bytes_read_ = 0;
+  uint64_t io_bytes_written_ = 0;
 };
 
 }  // namespace titandb

--- a/src/table_factory.cc
+++ b/src/table_factory.cc
@@ -29,7 +29,7 @@ TableBuilder* TitanTableFactory::NewTableBuilder(
   }
   return new TitanTableBuilder(column_family_id, db_options_, cf_options,
                                std::move(base_builder), blob_manager_,
-                               blob_storage, stats_);
+                               blob_storage, options.level, stats_);
 }
 
 std::string TitanTableFactory::GetPrintableTableOptions() const {

--- a/src/titan_options_test.cc
+++ b/src/titan_options_test.cc
@@ -1,0 +1,76 @@
+#include "test_util/testharness.h"
+
+#include "titan/db.h"
+
+namespace rocksdb {
+namespace titandb {
+
+class TitanOptionsTest : public testing::Test {
+ public:
+  TitanOptionsTest() : db_name_(test::TmpDir()) {
+    titan_options_.create_if_missing = true;
+    titan_options_.dirname = db_name_ + "/titandb";
+  }
+
+  ~TitanOptionsTest() {
+    Status s = Close();
+    assert(s.ok());
+  }
+
+  Status Open() { return TitanDB::Open(titan_options_, db_name_, &titan_db); }
+
+  Status DeleteDir(const std::string& dirname) {
+    Status s;
+    Env* env = Env::Default();
+    std::vector<std::string> filenames;
+    s = env->GetChildren(dirname, &filenames);
+    if (!s.ok()) {
+      return s;
+    }
+    for (auto& fname : filenames) {
+      s = env->DeleteFile(dirname + "/" + fname);
+      if (!s.ok()) {
+        return s;
+      }
+    }
+    s = env->DeleteDir(dirname);
+    return s;
+  }
+
+  Status Close() {
+    Status s;
+    if (titan_db != nullptr) {
+      s = titan_db->Close();
+      if (!s.ok()) {
+        return s;
+      }
+      titan_db = nullptr;
+      s = DeleteDir(titan_options_.dirname);
+      if (!s.ok()) {
+        return s;
+      }
+      rocksdb::Options opts;
+      s = rocksdb::DestroyDB(db_name_, opts);
+    }
+    return s;
+  }
+
+ protected:
+  std::string db_name_;
+  TitanOptions titan_options_;
+  TitanDB* titan_db = nullptr;
+};
+
+TEST_F(TitanOptionsTest, PurgeObsoleteFilesPeriodSec) {
+  titan_options_.purge_obsolete_files_period_sec = 0;
+  Status s = Open();
+  ASSERT_TRUE(s.IsInvalidArgument());
+}
+
+}  // namespace titandb
+}  // namespace rocksdb
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/titan_stats.cc
+++ b/src/titan_stats.cc
@@ -50,14 +50,15 @@ const std::array<std::string, static_cast<int>(InternalOpType::INTERNAL_OP_ENUM_
 void TitanInternalStats::DumpAndResetInternalOpStats(LogBuffer* log_buffer) {
   constexpr double GB = 1.0 * 1024 * 1024 * 1024;
   LogToBuffer(log_buffer,
-              "OP         COUNT  READ(GB)  WRITE(GB) IO_READ(GB) IO_WRITE(GB)  "
-              "FILE_IN FILE_OUT");
+              "OP           COUNT READ(GB)  WRITE(GB) IO_READ(GB) IO_WRITE(GB) "
+              " FILE_IN FILE_OUT");
   LogToBuffer(log_buffer,
-              "--------------------------------------------------------------");
+              "----------------------------------------------------------------"
+              "-----------------");
   for (int op = 0; op < static_cast<int>(InternalOpType::INTERNAL_OP_ENUM_MAX);
        op++) {
     LogToBuffer(
-        log_buffer, "%s %5d %8.1f %8.1f  %8.1f   %8.1f %8d %8d",
+        log_buffer, "%s %5d %10.1f %10.1f  %10.1f   %10.1f %8d %8d",
         internal_op_names[op].c_str(),
         GetAndResetStats(&internal_op_stats_[op], InternalOpStatsType::COUNT),
         GetAndResetStats(&internal_op_stats_[op],

--- a/src/titan_stats.cc
+++ b/src/titan_stats.cc
@@ -40,5 +40,44 @@ const std::unordered_map<std::string, TitanInternalStats::StatsType>
          TitanInternalStats::OBSOLETE_BLOB_FILE_SIZE},
 };
 
+const std::array<std::string, static_cast<int>(InternalOpType::INTERNAL_OP_ENUM_MAX)>
+    TitanInternalStats::internal_op_names = {
+  "Flush     ",
+  "Compaction",
+  "GC        ",
+};
+
+void TitanInternalStats::DumpAndResetInternalOpStats(LogBuffer* log_buffer) {
+  constexpr double GB = 1.0 * 1024 * 1024 * 1024;
+  LogToBuffer(log_buffer,
+              "OP         COUNT  READ(GB)  WRITE(GB) IO_READ(GB) IO_WRITE(GB)  "
+              "FILE_IN FILE_OUT");
+  LogToBuffer(log_buffer,
+              "--------------------------------------------------------------");
+  for (int op = 0; op < static_cast<int>(InternalOpType::INTERNAL_OP_ENUM_MAX);
+       op++) {
+    LogToBuffer(
+        log_buffer, "%s %5d %8.1f %8.1f  %8.1f   %8.1f %8d %8d",
+        internal_op_names[op].c_str(),
+        GetAndResetStats(&internal_op_stats_[op], InternalOpStatsType::COUNT),
+        GetAndResetStats(&internal_op_stats_[op],
+                         InternalOpStatsType::BYTES_READ) /
+            GB,
+        GetAndResetStats(&internal_op_stats_[op],
+                         InternalOpStatsType::BYTES_WRITTEN) /
+            GB,
+        GetAndResetStats(&internal_op_stats_[op],
+                         InternalOpStatsType::IO_BYTES_READ) /
+            GB,
+        GetAndResetStats(&internal_op_stats_[op],
+                         InternalOpStatsType::IO_BYTES_WRITTEN) /
+            GB,
+        GetAndResetStats(&internal_op_stats_[op],
+                         InternalOpStatsType::INPUT_FILE_NUM),
+        GetAndResetStats(&internal_op_stats_[op],
+                         InternalOpStatsType::OUTPUT_FILE_NUM));
+  }
+}
+
 }  // namespace titandb
 }  // namespace rocksdb

--- a/src/titan_stats.cc
+++ b/src/titan_stats.cc
@@ -40,11 +40,12 @@ const std::unordered_map<std::string, TitanInternalStats::StatsType>
          TitanInternalStats::OBSOLETE_BLOB_FILE_SIZE},
 };
 
-const std::array<std::string, static_cast<int>(InternalOpType::INTERNAL_OP_ENUM_MAX)>
+const std::array<std::string,
+                 static_cast<int>(InternalOpType::INTERNAL_OP_ENUM_MAX)>
     TitanInternalStats::internal_op_names = {
-  "Flush     ",
-  "Compaction",
-  "GC        ",
+        "Flush     ",
+        "Compaction",
+        "GC        ",
 };
 
 void TitanInternalStats::DumpAndResetInternalOpStats(LogBuffer* log_buffer) {

--- a/src/titan_stats.h
+++ b/src/titan_stats.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <map>
 #include <string>

--- a/src/titan_stats.h
+++ b/src/titan_stats.h
@@ -15,8 +15,6 @@ namespace titandb {
 
 enum class InternalOpStatsType : int {
   COUNT = 0,
-  TOTAL_SEC,
-  TOTAL_CPU_SEC,
   BYTES_READ,
   BYTES_WRITTEN,
   IO_BYTES_READ,

--- a/src/version_set.cc
+++ b/src/version_set.cc
@@ -266,7 +266,7 @@ Status VersionSet::DropColumnFamilies(
   return s;
 }
 
-Status VersionSet::DestroyColumnFamily(uint32_t cf_id) {
+Status VersionSet::MaybeDestroyColumnFamily(uint32_t cf_id) {
   obsolete_columns_.erase(cf_id);
   auto it = column_families_.find(cf_id);
   if (it != column_families_.end()) {

--- a/src/version_set.h
+++ b/src/version_set.h
@@ -50,7 +50,7 @@ class VersionSet {
   // Destroy the column family. Only after this is called, the obsolete files
   // of the dropped column family can be physical deleted.
   // REQUIRES: mutex is held
-  Status DestroyColumnFamily(uint32_t cf_id);
+  Status MaybeDestroyColumnFamily(uint32_t cf_id);
 
   // Allocates a new file number.
   uint64_t NewFileNumber() { return next_file_number_.fetch_add(1); }

--- a/src/version_test.cc
+++ b/src/version_test.cc
@@ -260,12 +260,12 @@ TEST_F(VersionTest, ObsoleteFiles) {
   ASSERT_EQ(of.size(), 1);
   CheckColumnFamiliesSize(10);
 
-  ASSERT_OK(vset_->DestroyColumnFamily(1));
+  ASSERT_OK(vset_->MaybeDestroyColumnFamily(1));
   vset_->GetObsoleteFiles(&of, kMaxSequenceNumber);
   ASSERT_EQ(of.size(), 4);
   CheckColumnFamiliesSize(9);
 
-  ASSERT_OK(vset_->DestroyColumnFamily(2));
+  ASSERT_OK(vset_->MaybeDestroyColumnFamily(2));
   CheckColumnFamiliesSize(8);
 }
 


### PR DESCRIPTION
Summary:
Add stats for read/write bytes and input/output file of internal operations and break down by operation type (being flush, compaction or GC). Later after we introduce vtable we can further breakdown compaction into top levels compaction, L_n-1 compaction and Ln compaction.

Test Plan:
Run db_bench and get sample output:
```
2019/08/29-23:49:29.593805 7f6fd97fa700 (Original Log Time 2019/08/29-23:49:29.593742) Titan internal stats for column family [default]:
2019/08/29-23:49:29.593813 7f6fd97fa700 (Original Log Time 2019/08/29-23:49:29.593753) OP          COUNT  READ(GB)  WRITE(GB) IO_READ(GB) IO_WRITE(GB)  FILE_IN FILE_OUT
2019/08/29-23:49:29.593821 7f6fd97fa700 (Original Log Time 2019/08/29-23:49:29.593760) ---------------------------------------------------------------------------------
2019/08/29-23:49:29.593830 7f6fd97fa700 (Original Log Time 2019/08/29-23:49:29.593768) Flush          3        0.0       34.7         0.0         18.0        0        3
2019/08/29-23:49:29.593839 7f6fd97fa700 (Original Log Time 2019/08/29-23:49:29.593784) Compaction     1        0.0        0.0         0.0          0.0        0        0
2019/08/29-23:49:29.593848 7f6fd97fa700 (Original Log Time 2019/08/29-23:49:29.593793) GC             1      360.9        1.3       354.3          2.8        8        0
```