### PR TITLE
Implement basic level merge for blob files

### DIFF
--- a/include/titan/options.h
+++ b/include/titan/options.h
@@ -118,6 +118,12 @@ struct TitanCFOptions : public ColumnFamilyOptions {
   // Default: kNormal
   TitanBlobRunMode blob_run_mode{TitanBlobRunMode::kNormal};
 
+  // If set true, values will be merged to a new blob file while their
+  // corresponding keys are compacted to last two level in LSM-Tree.
+  //
+  // Default: false
+  bool level_merge{false};
+
   TitanCFOptions() = default;
   explicit TitanCFOptions(const ColumnFamilyOptions& options)
       : ColumnFamilyOptions(options) {}

--- a/src/blob_file_builder.cc
+++ b/src/blob_file_builder.cc
@@ -25,6 +25,7 @@ void BlobFileBuilder::Add(const BlobRecord& record, BlobHandle* handle) {
   status_ = file_->Append(encoder_.GetHeader());
   if (ok()) {
     status_ = file_->Append(encoder_.GetRecord());
+    num_entries_++;
   }
 }
 
@@ -44,6 +45,8 @@ Status BlobFileBuilder::Finish() {
 }
 
 void BlobFileBuilder::Abandon() {}
+
+uint64_t BlobFileBuilder::NumEntries() { return num_entries_; }
 
 }  // namespace titandb
 }  // namespace rocksdb

--- a/src/blob_file_builder.h
+++ b/src/blob_file_builder.h
@@ -54,6 +54,9 @@ class BlobFileBuilder {
   // REQUIRES: Finish(), Abandon() have not been called.
   void Abandon();
 
+  // Number of calls to Add() so far.
+  uint64_t NumEntries();
+
  private:
   bool ok() const { return status().ok(); }
 
@@ -62,6 +65,8 @@ class BlobFileBuilder {
 
   Status status_;
   BlobEncoder encoder_;
+
+  uint64_t num_entries_{0};
 };
 
 }  // namespace titandb

--- a/src/blob_format.cc
+++ b/src/blob_format.cc
@@ -133,10 +133,13 @@ bool operator==(const BlobIndex& lhs, const BlobIndex& rhs) {
 void BlobFileMeta::EncodeTo(std::string* dst) const {
   PutVarint64(dst, file_number_);
   PutVarint64(dst, file_size_);
+  PutVarint64(dst, file_entries_);
+  PutVarint32(dst, file_level_);
 }
 
 Status BlobFileMeta::DecodeFrom(Slice* src) {
-  if (!GetVarint64(src, &file_number_) || !GetVarint64(src, &file_size_)) {
+  if (!GetVarint64(src, &file_number_) || !GetVarint64(src, &file_size_) ||
+      !GetVarint64(src, &file_entries_) || !GetVarint32(src, &file_level_)) {
     return Status::Corruption("BlobFileMeta Decode failed");
   }
   return Status::OK();
@@ -144,7 +147,9 @@ Status BlobFileMeta::DecodeFrom(Slice* src) {
 
 bool operator==(const BlobFileMeta& lhs, const BlobFileMeta& rhs) {
   return (lhs.file_number_ == rhs.file_number_ &&
-          lhs.file_size_ == rhs.file_size_);
+          lhs.file_size_ == rhs.file_size_ &&
+          lhs.file_entries_ == rhs.file_entries_ &&
+          lhs.file_level_ == rhs.file_level_);
 }
 
 void BlobFileMeta::FileStateTransit(const FileEvent& event) {

--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -129,8 +129,16 @@ class BlobFileMeta {
   };
 
   BlobFileMeta() = default;
+
   BlobFileMeta(uint64_t _file_number, uint64_t _file_size)
       : file_number_(_file_number), file_size_(_file_size) {}
+
+  BlobFileMeta(uint64_t _file_number, uint64_t _file_size,
+               uint64_t _file_entries, uint32_t _file_level)
+      : file_number_(_file_number),
+        file_size_(_file_size),
+        file_entries_(_file_entries),
+        file_level_(_file_level) {}
 
   friend bool operator==(const BlobFileMeta& lhs, const BlobFileMeta& rhs);
 
@@ -139,6 +147,7 @@ class BlobFileMeta {
 
   uint64_t file_number() const { return file_number_; }
   uint64_t file_size() const { return file_size_; }
+  uint32_t file_level() const { return file_level_; }
   FileState file_state() const { return state_; }
   bool is_obsolete() const { return state_ == FileState::kObsolete; }
   uint64_t discardable_size() const { return discardable_size_; }
@@ -155,6 +164,8 @@ class BlobFileMeta {
   // Persistent field
   uint64_t file_number_{0};
   uint64_t file_size_{0};
+  uint64_t file_entries_{0};
+  uint32_t file_level_{0};
 
   // Not persistent field
   FileState state_{FileState::kInit};

--- a/src/db_impl.cc
+++ b/src/db_impl.cc
@@ -211,8 +211,8 @@ Status TitanDBImpl::Open(const std::vector<TitanCFDescriptor>& descs,
                                   MutableTitanCFOptions(descs[i].options));
       base_table_factory_[cf_id] = base_table_factory;
       titan_table_factory_[cf_id] = std::make_shared<TitanTableFactory>(
-          db_options_, descs[i].options, blob_manager_, &mutex_, vset_.get(),
-          stats_.get());
+          db_impl_, db_options_, descs[i].options, blob_manager_, &mutex_,
+          vset_.get(), stats_.get());
       base_descs[i].options.table_factory = titan_table_factory_[cf_id];
       // Add TableProperties for collecting statistics GC
       base_descs[i].options.table_properties_collector_factories.emplace_back(
@@ -323,8 +323,8 @@ Status TitanDBImpl::CreateColumnFamilies(
     // Replaces the provided table factory with TitanTableFactory.
     base_table_factory.emplace_back(options.table_factory);
     titan_table_factory.emplace_back(std::make_shared<TitanTableFactory>(
-        db_options_, desc.options, blob_manager_, &mutex_, vset_.get(),
-        stats_.get()));
+        db_impl_, db_options_, desc.options, blob_manager_, &mutex_,
+        vset_.get(), stats_.get()));
     options.table_factory = titan_table_factory.back();
     base_descs.emplace_back(desc.name, options);
   }

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -60,6 +60,37 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
       AppendInternalKey(&index_key, ikey);
       base_builder_->Add(index_key, index_value);
     }
+  } else if (ikey.type == kTypeBlobIndex && cf_options_.level_merge &&
+             target_level_ >= merge_level_) {
+    // we merge value to new blob file
+    BlobIndex index;
+    Slice copy = value;
+    status_ = index.DecodeFrom(&copy);
+    if (!ok()) {
+      return;
+    }
+    auto storage = blob_storage_.lock();
+    assert(storage != nullptr);
+    auto blob_file = storage->FindFile(index.file_number).lock();
+    if (blob_file != nullptr && (int)blob_file->file_level() < target_level_) {
+      BlobRecord record;
+      PinnableSlice buffer;
+      Status s = storage->Get(ReadOptions(), index, &record, &buffer);
+      if (s.ok()) {
+        std::string index_value;
+        AddBlob(ikey.user_key, record.value, &index_value);
+        if (ok()) {
+          std::string index_key;
+          ikey.type = kTypeBlobIndex;
+          AppendInternalKey(&index_key, ikey);
+          base_builder_->Add(index_key, index_value);
+        }
+      } else {
+        base_builder_->Add(key, value);
+      }
+    } else {
+      base_builder_->Add(key, value);
+    }
   } else {
     base_builder_->Add(key, value);
   }
@@ -95,6 +126,34 @@ void TitanTableBuilder::AddBlob(const Slice& key, const Slice& value,
   RecordTick(stats_, BLOB_DB_BLOB_FILE_BYTES_WRITTEN, index.blob_handle.size);
   if (ok()) {
     index.EncodeTo(index_value);
+    if (blob_handle_->GetFile()->GetFileSize() >=
+        cf_options_.blob_file_target_size) {
+      FinishBlob();
+    }
+  }
+}
+
+void TitanTableBuilder::FinishBlob() {
+  if (blob_builder_) {
+    blob_builder_->Finish();
+    if (ok()) {
+      ROCKS_LOG_INFO(db_options_.info_log,
+                     "Titan table builder finish output file %" PRIu64 ".",
+                     blob_handle_->GetNumber());
+      std::shared_ptr<BlobFileMeta> file = std::make_shared<BlobFileMeta>(
+          blob_handle_->GetNumber(), blob_handle_->GetFile()->GetFileSize(),
+          blob_builder_->NumEntries(), target_level_);
+      file->FileStateTransit(BlobFileMeta::FileEvent::kFlushOrCompactionOutput);
+      status_ =
+          blob_manager_->FinishFile(cf_id_, file, std::move(blob_handle_));
+      blob_builder_.reset();
+    } else {
+      ROCKS_LOG_WARN(
+          db_options_.info_log,
+          "Titan table builder finish failed. Delete output file %" PRIu64 ".",
+          blob_handle_->GetNumber());
+      status_ = blob_manager_->DeleteFile(std::move(blob_handle_));
+    }
   }
 }
 
@@ -111,25 +170,7 @@ Status TitanTableBuilder::status() const {
 
 Status TitanTableBuilder::Finish() {
   base_builder_->Finish();
-  if (blob_builder_) {
-    blob_builder_->Finish();
-    if (ok()) {
-      ROCKS_LOG_INFO(db_options_.info_log,
-                     "Titan table builder finish output file %" PRIu64 ".",
-                     blob_handle_->GetNumber());
-      std::shared_ptr<BlobFileMeta> file = std::make_shared<BlobFileMeta>(
-          blob_handle_->GetNumber(), blob_handle_->GetFile()->GetFileSize());
-      file->FileStateTransit(BlobFileMeta::FileEvent::kFlushOrCompactionOutput);
-      status_ =
-          blob_manager_->FinishFile(cf_id_, file, std::move(blob_handle_));
-    } else {
-      ROCKS_LOG_WARN(
-          db_options_.info_log,
-          "Titan table builder finish failed. Delete output file %" PRIu64 ".",
-          blob_handle_->GetNumber());
-      status_ = blob_manager_->DeleteFile(std::move(blob_handle_));
-    }
-  }
+  FinishBlob();
   if (!status_.ok()) {
     ROCKS_LOG_ERROR(db_options_.info_log,
                     "Titan table builder failed on finish: %s",
@@ -164,6 +205,11 @@ bool TitanTableBuilder::NeedCompact() const {
 
 TableProperties TitanTableBuilder::GetTableProperties() const {
   return base_builder_->GetTableProperties();
+}
+
+bool TitanTableBuilder::ShouldMerge(
+    const std::shared_ptr<rocksdb::titandb::BlobFileMeta>& file) {
+  return file != nullptr && (int)file->file_level() < target_level_;
 }
 
 }  // namespace titandb

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -72,7 +72,7 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
     auto storage = blob_storage_.lock();
     assert(storage != nullptr);
     auto blob_file = storage->FindFile(index.file_number).lock();
-    if (blob_file != nullptr && (int)blob_file->file_level() < target_level_) {
+    if (ShouldMerge(blob_file)) {
       BlobRecord record;
       PinnableSlice buffer;
       Status s = storage->Get(ReadOptions(), index, &record, &buffer);

--- a/src/table_builder.h
+++ b/src/table_builder.h
@@ -17,9 +17,9 @@ class TitanTableBuilder : public TableBuilder {
                     std::unique_ptr<TableBuilder> base_builder,
                     std::shared_ptr<BlobFileManager> blob_manager,
                     std::weak_ptr<BlobStorage> blob_storage, TitanStats* stats,
-                    int num_levels, int target_level)
+                    int merge_level, int target_level)
       : cf_id_(cf_id),
-        merge_level_(std::max(num_levels - 1, 2)),
+        merge_level_(merge_level),
         target_level_(target_level),
         db_options_(db_options),
         cf_options_(cf_options),
@@ -52,6 +52,8 @@ class TitanTableBuilder : public TableBuilder {
   bool ShouldMerge(const std::shared_ptr<BlobFileMeta>& file);
 
   void FinishBlob();
+
+  friend class TableBuilderTest;
 
   Status status_;
   uint32_t cf_id_;

--- a/src/table_builder_test.cc
+++ b/src/table_builder_test.cc
@@ -83,7 +83,7 @@ class TableBuilderTest : public testing::Test {
     cf_options_.min_blob_size = kMinBlobSize;
     vset_.reset(new VersionSet(db_options_, nullptr));
     blob_manager_.reset(new FileManager(db_options_));
-    table_factory_.reset(new TitanTableFactory(db_options_, cf_options_,
+    table_factory_.reset(new TitanTableFactory(db_, db_options_, cf_options_,
                                                blob_manager_, &mutex_,
                                                vset_.get(), nullptr));
   }
@@ -158,6 +158,7 @@ class TableBuilderTest : public testing::Test {
 
   port::Mutex mutex_;
 
+  DBImpl* db_{nullptr};
   Env* env_{Env::Default()};
   EnvOptions env_options_;
   Options options_;

--- a/src/table_factory.cc
+++ b/src/table_factory.cc
@@ -23,19 +23,25 @@ TableBuilder* TitanTableFactory::NewTableBuilder(
   TitanCFOptions cf_options = cf_options_;
   cf_options.blob_run_mode = blob_run_mode_.load();
   std::weak_ptr<BlobStorage> blob_storage;
-  int num_levels =
-      db_impl_ == nullptr
-          ? INT_MAX
-          : db_impl_->NumberLevels(
-                db_impl_->GetColumnFamilyHandleUnlocked(column_family_id)
-                    .get());
+  // While table factory constructed in titan for first time, db_impl_ is
+  // uninitialized (nullptr), and flush may trigger. Since flush won't merge
+  // blob files, we set merge level to a unreachable value.
+  int num_levels = INT_MAX;
+  if (db_impl_ != nullptr) {
+    InstrumentedMutexLock l(db_impl_->mutex());
+    auto cfh = reinterpret_cast<ColumnFamilyHandleImpl*>(
+        db_impl_->GetColumnFamilyHandle(column_family_id));
+    auto cfd = cfh->cfd();
+    num_levels = cfd->current()->storage_info()->num_non_empty_levels();
+  }
   {
     MutexLock l(db_mutex_);
     blob_storage = vset_->GetBlobStorage(column_family_id);
   }
-  return new TitanTableBuilder(column_family_id, db_options_, cf_options,
-                               std::move(base_builder), blob_manager_,
-                               blob_storage, stats_, num_levels, options.level);
+  return new TitanTableBuilder(
+      column_family_id, db_options_, cf_options, std::move(base_builder),
+      blob_manager_, blob_storage, stats_,
+      std::max(1, num_levels - 2) /* merge level */, options.level);
 }
 
 std::string TitanTableFactory::GetPrintableTableOptions() const {

--- a/src/table_factory.cc
+++ b/src/table_factory.cc
@@ -23,13 +23,19 @@ TableBuilder* TitanTableFactory::NewTableBuilder(
   TitanCFOptions cf_options = cf_options_;
   cf_options.blob_run_mode = blob_run_mode_.load();
   std::weak_ptr<BlobStorage> blob_storage;
+  int num_levels =
+      db_impl_ == nullptr
+          ? INT_MAX
+          : db_impl_->NumberLevels(
+                db_impl_->GetColumnFamilyHandleUnlocked(column_family_id)
+                    .get());
   {
     MutexLock l(db_mutex_);
     blob_storage = vset_->GetBlobStorage(column_family_id);
   }
   return new TitanTableBuilder(column_family_id, db_options_, cf_options,
                                std::move(base_builder), blob_manager_,
-                               blob_storage, stats_);
+                               blob_storage, stats_, num_levels, options.level);
 }
 
 std::string TitanTableFactory::GetPrintableTableOptions() const {

--- a/src/table_factory.h
+++ b/src/table_factory.h
@@ -3,6 +3,7 @@
 #include <atomic>
 
 #include "blob_file_manager.h"
+#include "db/db_impl/db_impl.h"
 #include "rocksdb/table.h"
 #include "titan/options.h"
 #include "titan_stats.h"
@@ -13,11 +14,12 @@ namespace titandb {
 
 class TitanTableFactory : public TableFactory {
  public:
-  TitanTableFactory(const TitanDBOptions& db_options,
+  TitanTableFactory(DBImpl*& db_impl, const TitanDBOptions& db_options,
                     const TitanCFOptions& cf_options,
                     std::shared_ptr<BlobFileManager> blob_manager,
                     port::Mutex* db_mutex, VersionSet* vset, TitanStats* stats)
-      : db_options_(db_options),
+      : db_impl_(db_impl),
+        db_options_(db_options),
         cf_options_(cf_options),
         blob_run_mode_(cf_options.blob_run_mode),
         base_factory_(cf_options.table_factory),
@@ -61,6 +63,7 @@ class TitanTableFactory : public TableFactory {
   }
 
  private:
+  DBImpl*& db_impl_;
   const TitanDBOptions db_options_;
   const TitanCFOptions cf_options_;
   std::atomic<TitanBlobRunMode> blob_run_mode_;

--- a/src/table_factory.h
+++ b/src/table_factory.h
@@ -63,7 +63,9 @@ class TitanTableFactory : public TableFactory {
   }
 
  private:
-  DBImpl*& db_impl_;
+  // we use reference here because table factory is constructed before
+  // initialize db_impl_ in titan
+  DBImpl* const& db_impl_;
   const TitanDBOptions db_options_;
   const TitanCFOptions cf_options_;
   std::atomic<TitanBlobRunMode> blob_run_mode_;

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -12,7 +12,6 @@
 #include "blob_file_reader.h"
 #include "db_impl.h"
 #include "db_iter.h"
-#include "iostream"
 #include "titan/db.h"
 #include "titan_fault_injection_test_env.h"
 

--- a/src/titan_db_test.cc
+++ b/src/titan_db_test.cc
@@ -12,6 +12,7 @@
 #include "blob_file_reader.h"
 #include "db_impl.h"
 #include "db_iter.h"
+#include "iostream"
 #include "titan/db.h"
 #include "titan_fault_injection_test_env.h"
 


### PR DESCRIPTION
- Record blob file's level, which is decided by target level of the compaction or flush that generates this blob file.
- Add a option to enable level merge. With level merge enabled, titan table builder will merge values of blob files to a new blob file if:
    - blob file's level lower than builder target level, and
    - target level is higher than or equals to merge level. we set merge level to max(1, cf's highest level-1) for now.
- Limit blob file size to blob_file_target_size in table builder, to avoid generate large blob files during level merge.