### PR TITLE
Fix blob file format description

### DIFF
--- a/src/blob_format.h
+++ b/src/blob_format.h
@@ -16,11 +16,6 @@ namespace titandb {
 // [blob head + record 2]
 // ...
 // [blob head + record N]
-// [meta block 1]
-// [meta block 2]
-// ...
-// [meta block K]
-// [meta index block]
 // [blob file footer]
 
 // Format of blob head (9 bytes):


### PR DESCRIPTION
Summary:
Blob file does not come with meta blocks. Fix the inline description.

Test Plan:
N/A

Signed-off-by: Yi Wu <yiwu@pingcap.com>