### PR TITLE
Fix missing-braces compile warning

### DIFF
--- a/src/titan_stats.cc
+++ b/src/titan_stats.cc
@@ -76,7 +76,7 @@ const std::array<std::string,
         "Flush     ",
         "Compaction",
         "GC        ",
-}};
+    }};
 
 void TitanInternalStats::DumpAndResetInternalOpStats(LogBuffer* log_buffer) {
   constexpr double GB = 1.0 * 1024 * 1024 * 1024;

--- a/src/titan_stats.cc
+++ b/src/titan_stats.cc
@@ -72,11 +72,11 @@ const std::unordered_map<std::string, TitanInternalStats::StatsType>
 
 const std::array<std::string,
                  static_cast<int>(InternalOpType::INTERNAL_OP_ENUM_MAX)>
-    TitanInternalStats::internal_op_names = {
+    TitanInternalStats::internal_op_names = {{
         "Flush     ",
         "Compaction",
         "GC        ",
-};
+}};
 
 void TitanInternalStats::DumpAndResetInternalOpStats(LogBuffer* log_buffer) {
   constexpr double GB = 1.0 * 1024 * 1024 * 1024;


### PR DESCRIPTION
Summary:
Fixing -Wmissing-braces compile warning, e.g. https://travis-ci.org/pingcap/rust-rocksdb/jobs/587241018

Test Plan:
`cmake .. -DCMAKE_CXX_FLAGS="-Wmissing-braces" && make src/titan_stats.o` without compile error.

Signed-off-by: Yi Wu <yiwu@pingcap.com>