### PR TITLE
titandb_stress print git hash

### DIFF
--- a/tools/titandb_stress.cc
+++ b/tools/titandb_stress.cc
@@ -60,6 +60,7 @@ int main() {
 #include "rocksdb/utilities/transaction.h"
 #include "rocksdb/utilities/transaction_db.h"
 #include "rocksdb/write_batch.h"
+#include "util/build_version.h"
 #include "util/coding.h"
 #include "util/compression.h"
 #include "util/crc32c.h"
@@ -76,6 +77,7 @@ int main() {
 #include "utilities/merge_operators.h"
 
 #include "titan/db.h"
+#include "titan_build_version.h"
 
 using GFLAGS_NAMESPACE::ParseCommandLineFlags;
 using GFLAGS_NAMESPACE::RegisterFlagValidator;
@@ -2639,6 +2641,8 @@ class StressTest {
   void PrintEnv() const {
     fprintf(stdout, "RocksDB version           : %d.%d\n", kMajorVersion,
             kMinorVersion);
+    fprintf(stdout, "RocksDB hash              : %s\n", rocksdb_build_git_sha);
+    fprintf(stdout, "Titan hash                : %s\n", titan_build_git_sha);
     fprintf(stdout, "Format version            : %d\n", FLAGS_format_version);
     fprintf(stdout, "TransactionDB             : %s\n",
             FLAGS_use_txn ? "true" : "false");


### PR DESCRIPTION
Summary:
Make titandb_stress print rocksdb and titan git hash at the beginning. This is useful in schordinger test to verify which version is being tested.

Test Plan:
run titandb_stress, which prints the following at the beginning:
```
2019/10/25-05:59:22  Initializing db_stress
RocksDB version           : 6.4
RocksDB hash              : rocksdb_build_git_sha:@9ab5a5f9e70d2ea5fc9bd22a455d52a5d082fd57@
Titan hash                : titan_build_git_sha:@b497731e50eaa17af1bb17697c1d6e88a9aae670@
```

Signed-off-by: Yi Wu <yiwu@pingcap.com>