### PR TITLE
Revert wait for flush before GC

### DIFF
--- a/src/db_impl_gc.cc
+++ b/src/db_impl_gc.cc
@@ -107,12 +107,6 @@ Status TitanDBImpl::BackgroundGC(LogBuffer* log_buffer,
     // Nothing to do
     ROCKS_LOG_BUFFER(log_buffer, "Titan GC nothing to do");
   } else {
-    {
-      mutex_.Unlock();
-      auto* cfd = reinterpret_cast<ColumnFamilyHandleImpl*>(cfh.get())->cfd();
-      db_impl_->WaitForFlushMemTable(cfd);
-      mutex_.Lock();
-    }
     BlobGCJob blob_gc_job(blob_gc.get(), db_, &mutex_, db_options_, env_,
                           env_options_, blob_manager_.get(),
                           blob_file_set_.get(), log_buffer, &shuting_down_,


### PR DESCRIPTION
Summary:
Revert temp fix introduced in #96 which wait for memtable flush before a GC job, since potentially that can make GC starve if there are ongoing flush. We can revert the fix in favor of the fix from rocksdb upstream: https://github.com/pingcap/rocksdb/pull/127

Test Plan:
Make sure TitanDBTest::GCBeforeFlushCommit test still passes.

Signed-off-by: Yi Wu <yiwu@pingcap.com>