### PR TITLE
Fix db cleanup in blob_gc_job_test

### DIFF
--- a/src/blob_gc_job_test.cc
+++ b/src/blob_gc_job_test.cc
@@ -41,7 +41,7 @@ class BlobGCJobTest : public testing::Test {
     options_.env->CreateDirIfMissing(dbname_);
     options_.env->CreateDirIfMissing(options_.dirname);
   }
-  ~BlobGCJobTest() {}
+  ~BlobGCJobTest() { Close(); }
 
   void DisableMergeSmall() { options_.merge_small_file_threshold = 0; }
 
@@ -87,7 +87,7 @@ class BlobGCJobTest : public testing::Test {
   }
 
   void Reopen() {
-    DestroyDB();
+    Close();
     Open();
   }
 
@@ -119,9 +119,10 @@ class BlobGCJobTest : public testing::Test {
     b->ComputeGCScore();
   }
 
-  void DestroyDB() {
-    Status s __attribute__((__unused__)) = db_->Close();
-    assert(s.ok());
+  void Close() {
+    if (!db_)
+      return;
+    ASSERT_OK(db_->Close());
     delete db_;
     db_ = nullptr;
   }
@@ -220,7 +221,6 @@ class BlobGCJobTest : public testing::Test {
     bool discardable = false;
     ASSERT_OK(blob_gc_job.DiscardEntry(key, blob_index, &discardable));
     ASSERT_FALSE(discardable);
-    DestroyDB();
   }
 
   void TestRunGC() {
@@ -277,7 +277,6 @@ class BlobGCJobTest : public testing::Test {
     }
     delete db_iter;
     ASSERT_FALSE(iter->Valid() || !iter->status().ok());
-    DestroyDB();
   }
 };
 
@@ -354,7 +353,7 @@ TEST_F(BlobGCJobTest, GCLimiter) {
   RunGC(true);
   ASSERT_TRUE(test_limiter->WriteRequested());
   ASSERT_FALSE(test_limiter->ReadRequested());
-  DestroyDB();
+  Close();
 
   test_limiter = new TestLimiter(RateLimiter::Mode::kReadsOnly);
   options_.rate_limiter.reset(test_limiter);
@@ -364,7 +363,7 @@ TEST_F(BlobGCJobTest, GCLimiter) {
   RunGC(true);
   ASSERT_FALSE(test_limiter->WriteRequested());
   ASSERT_TRUE(test_limiter->ReadRequested());
-  DestroyDB();
+  Close();
 
   test_limiter = new TestLimiter(RateLimiter::Mode::kAllIo);
   options_.rate_limiter.reset(test_limiter);
@@ -374,7 +373,7 @@ TEST_F(BlobGCJobTest, GCLimiter) {
   RunGC(true);
   ASSERT_TRUE(test_limiter->WriteRequested());
   ASSERT_TRUE(test_limiter->ReadRequested());
-  DestroyDB();
+  Close();
 }
 
 TEST_F(BlobGCJobTest, Reopen) {
@@ -397,8 +396,6 @@ TEST_F(BlobGCJobTest, Reopen) {
 
   RunGC(false, true);
   CheckBlobNumber(1);
-
-  DestroyDB();
 }
 
 // Tests blob file will be kept after GC, if it is still visible by active
@@ -456,8 +453,6 @@ TEST_F(BlobGCJobTest, PurgeBlobs) {
 
   RunGC(false);
   CheckBlobNumber(1);
-
-  DestroyDB();
 }
 
 TEST_F(BlobGCJobTest, DeleteFilesInRange) {
@@ -549,8 +544,6 @@ TEST_F(BlobGCJobTest, DeleteFilesInRange) {
   }
   ASSERT_OK(iter->status());
   delete iter;
-
-  DestroyDB();
 }
 
 TEST_F(BlobGCJobTest, LevelMergeGC) {
@@ -602,8 +595,6 @@ TEST_F(BlobGCJobTest, LevelMergeGC) {
             BlobFileMeta::FileState::kObsolete);
   ASSERT_EQ(b->FindFile(5).lock()->file_state(),
             BlobFileMeta::FileState::kNormal);
-
-  DestroyDB();
 }
 
 TEST_F(BlobGCJobTest, RangeMergeScheduler) {
@@ -775,8 +766,6 @@ TEST_F(BlobGCJobTest, RangeMergeScheduler) {
       files[i]->FileStateTransit(BlobFileMeta::FileEvent::kReset);
     }
   }
-
-  DestroyDB();
 }
 
 TEST_F(BlobGCJobTest, RangeMerge) {
@@ -827,8 +816,6 @@ TEST_F(BlobGCJobTest, RangeMerge) {
     auto blob = b->FindFile(i).lock();
     ASSERT_EQ(blob->file_state(), BlobFileMeta::FileState::kObsolete);
   }
-
-  DestroyDB();
 }
 }  // namespace titandb
 

--- a/src/blob_gc_job_test.cc
+++ b/src/blob_gc_job_test.cc
@@ -120,8 +120,7 @@ class BlobGCJobTest : public testing::Test {
   }
 
   void Close() {
-    if (!db_)
-      return;
+    if (!db_) return;
     ASSERT_OK(db_->Close());
     delete db_;
     db_ = nullptr;


### PR DESCRIPTION
Move db cleanup to GTest fixture destructor so that a broken test won't affect subsequent tests in this way:

```
[==========] Running 9 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 9 tests from BlobGCJobTest
[ RUN      ] BlobGCJobTest.DiscardEntry
[       OK ] BlobGCJobTest.DiscardEntry (118 ms)
[ RUN      ] BlobGCJobTest.RunGC
/home/pingcap/tabokie/titan/src/blob_gc_job_test.cc:274: Failure
Value of: db_iter->value().compare(Slice(GenValue(i))) == 0
  Actual: false
Expected: true
[  FAILED  ] BlobGCJobTest.RunGC (142 ms)
[ RUN      ] BlobGCJobTest.GCLimiter
/home/pingcap/tabokie/titan/src/blob_gc_job_test.cc:82: Failure
TitanDB::Open(options_, dbname_, &db_)
IO error: lock : /tmp/rocksdbtest-1000/titandb/LOCK: No locks available
titan_blob_gc_job_test: /home/pingcap/tabokie/titan/src/blob_gc_job_test.cc:338: rocksdb::titandb::BlobGCJobTest_GCLimiter_Test::TestBody()::__lambda8: Assertion `db_' failed.
[1]    189356 abort (core dumped)  ./titan_blob_gc_job_test
```

Signed-off-by: tabokie <xy.tao@outlook.com>