### PR TITLE
Fix stats for `io_stats_bytes`

### DIFF
--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -89,6 +89,8 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
       if (s.ok()) {
         std::string index_value;
         AddBlob(ikey.user_key, record.value, &index_value);
+        UpdateIOBytes(prev_bytes_read, prev_bytes_written, &io_bytes_read_,
+                  &io_bytes_written_);
         if (ok()) {
           std::string index_key;
           ikey.type = kTypeBlobIndex;

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -90,7 +90,7 @@ void TitanTableBuilder::Add(const Slice& key, const Slice& value) {
         std::string index_value;
         AddBlob(ikey.user_key, record.value, &index_value);
         UpdateIOBytes(prev_bytes_read, prev_bytes_written, &io_bytes_read_,
-                  &io_bytes_written_);
+                      &io_bytes_written_);
         if (ok()) {
           std::string index_key;
           ikey.type = kTypeBlobIndex;

--- a/src/table_builder.cc
+++ b/src/table_builder.cc
@@ -146,7 +146,13 @@ void TitanTableBuilder::AddBlob(const Slice& key, const Slice& value,
 
 void TitanTableBuilder::FinishBlobFile() {
   if (blob_builder_) {
+    uint64_t prev_bytes_read = 0;
+    uint64_t prev_bytes_written = 0;
+    SavePrevIOBytes(&prev_bytes_read, &prev_bytes_written);
     blob_builder_->Finish();
+    UpdateIOBytes(prev_bytes_read, prev_bytes_written, &io_bytes_read_,
+                  &io_bytes_written_);
+
     if (ok()) {
       ROCKS_LOG_INFO(db_options_.info_log,
                      "Titan table builder finish output file %" PRIu64 ".",

--- a/src/titan_stats.cc
+++ b/src/titan_stats.cc
@@ -81,9 +81,10 @@ const std::array<std::string,
 void TitanInternalStats::DumpAndResetInternalOpStats(LogBuffer* log_buffer) {
   constexpr double GB = 1.0 * 1024 * 1024 * 1024;
   constexpr double SECOND = 1.0 * 1000000;
-  LogToBuffer(log_buffer,
-              "OP           COUNT READ(GB)  WRITE(GB) IO_READ(GB) IO_WRITE(GB) "
-              " FILE_IN FILE_OUT GC_SAMPLE(MICROS) GC_READ(MICROS) GC_UPDATE(MICROS)");
+  LogToBuffer(
+      log_buffer,
+      "OP           COUNT READ(GB)  WRITE(GB) IO_READ(GB) IO_WRITE(GB) "
+      " FILE_IN FILE_OUT GC_SAMPLE(MICROS) GC_READ(MICROS) GC_UPDATE(MICROS)");
   LogToBuffer(log_buffer,
               "----------------------------------------------------------------"
               "-----------------");

--- a/src/titan_stats.cc
+++ b/src/titan_stats.cc
@@ -83,7 +83,7 @@ void TitanInternalStats::DumpAndResetInternalOpStats(LogBuffer* log_buffer) {
   constexpr double SECOND = 1.0 * 1000000;
   LogToBuffer(log_buffer,
               "OP           COUNT READ(GB)  WRITE(GB) IO_READ(GB) IO_WRITE(GB) "
-              " FILE_IN FILE_OUT");
+              " FILE_IN FILE_OUT GC_SAMPLE(MICROS) GC_READ(MICROS) GC_UPDATE(MICROS)");
   LogToBuffer(log_buffer,
               "----------------------------------------------------------------"
               "-----------------");


### PR DESCRIPTION
We count io bytes before and after adding blob records. But there is a buffer inside, so we should count it when finishing blob files too.