### PR TITLE
Fix status overrided by mistake

### DIFF
--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -520,12 +520,12 @@ Status BlobGCJob::InstallOutputBlobFiles() {
       to_delete_files.append(std::to_string(builder.first->GetNumber()));
       handles.emplace_back(std::move(builder.first));
     }
-    ROCKS_LOG_BUFFER(
-        log_buffer_,
-        "[%s] InstallOutputBlobFiles failed. Delete GC output files: %s",
-        blob_gc_->column_family_handle()->GetName().c_str(),
-        to_delete_files.c_str());
-    s = blob_file_manager_->BatchDeleteFiles(handles);
+    Status status = blob_file_manager_->BatchDeleteFiles(handles);
+    ROCKS_LOG_BUFFER(log_buffer_,
+                     "[%s] InstallOutputBlobFiles failed. Delete GC output "
+                     "files: %s with status: %s",
+                     blob_gc_->column_family_handle()->GetName().c_str(),
+                     to_delete_files.c_str(), status.ToString().c_str());
   }
   return s;
 }

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -520,12 +520,19 @@ Status BlobGCJob::InstallOutputBlobFiles() {
       to_delete_files.append(std::to_string(builder.first->GetNumber()));
       handles.emplace_back(std::move(builder.first));
     }
-    Status status = blob_file_manager_->BatchDeleteFiles(handles);
     ROCKS_LOG_BUFFER(log_buffer_,
                      "[%s] InstallOutputBlobFiles failed. Delete GC output "
-                     "files: %s with status: %s",
+                     "files: %s",
                      blob_gc_->column_family_handle()->GetName().c_str(),
+                     to_delete_files.c_str());
+    // Do not set status `s` here, cause it may override the non-okay-status of
+    // `s` so that in the outer funcation it will rewrite blob indexes to LSM by
+    // mistake.
+    Status status = blob_file_manager_->BatchDeleteFiles(handles);
+    if (!status.ok()) {
+      ROCKS_LOG_WARN(log_buffer_, "Delete GC output files[%s] failed: %s",
                      to_delete_files.c_str(), status.ToString().c_str());
+    }
   }
   return s;
 }

--- a/src/blob_gc_job.cc
+++ b/src/blob_gc_job.cc
@@ -530,7 +530,8 @@ Status BlobGCJob::InstallOutputBlobFiles() {
     // mistake.
     Status status = blob_file_manager_->BatchDeleteFiles(handles);
     if (!status.ok()) {
-      ROCKS_LOG_WARN(log_buffer_, "Delete GC output files[%s] failed: %s",
+      ROCKS_LOG_WARN(db_options_.info_log,
+                     "Delete GC output files[%s] failed: %s",
                      to_delete_files.c_str(), status.ToString().c_str());
     }
   }


### PR DESCRIPTION
When `InstallOutputBlobFiles`, if there is an error of finishing a blob file, Titan would delete the blob file physically. But now, the non-okay-status is overridden by the okay-result of deleting files. So in the outer place, it would rewrite blob index to LSM as usual while the blob file is actually 
deleted.